### PR TITLE
Updated: Silent cmd launch for OpenFolder/OpenFileWithDefaultProgram

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Utility/ProcessExtensions.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Utility/ProcessExtensions.cs
@@ -106,7 +106,11 @@ public static unsafe class ProcessExtensions
     /// </summary>
     public static void OpenFileWithExplorer(string url)
     {
-        Process.Start(new ProcessStartInfo("cmd", $"/c start explorer \"{url}\""));
+        Process.Start(new ProcessStartInfo("cmd", $"/c start explorer \"{url}\"")
+        {
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        });
     }
 
     /// <summary>
@@ -114,7 +118,11 @@ public static unsafe class ProcessExtensions
     /// </summary>
     public static void OpenFileWithDefaultProgram(string url)
     {
-        Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{url}\""));
+        Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{url}\"")
+        {
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
* Silently launches cmd for OpenFolder/OpenFileWIthDefaultProgram
* Makes the brief CMD window pop up when a user 'open folder' 's  a mod or launches the help links not appear