### PR TITLE
Add environment variable check to mod template

### DIFF
--- a/source/Reloaded.Mod.Template/templates/configurable/.github/workflows/reloaded.yml
+++ b/source/Reloaded.Mod.Template/templates/configurable/.github/workflows/reloaded.yml
@@ -31,6 +31,8 @@ env:
   
   PUBLISH_CHANGELOG_PATH: ./Publish/Changelog.md
   PUBLISH_PATH: ./Publish
+  
+  RELOADEDIIMODS: .
 
   # Default value is official Reloaded package server.  
   NUGET_URL: http://packages.sewer56.moe:5000/v3/index.json

--- a/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Checks.targets
+++ b/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Checks.targets
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+	
+  <!-- Checks if environment variables are set -->
+  <Target Name="ReloadedEnvironmentVariableCheck" BeforeTargets="Build">
+    <Error Condition="$(RELOADEDIIMODS) == ''" Text="RELOADEDIIMODS environment variable is not set. Make sure you set this variable to the path of your Reloaded-II mods folder." />
+  </Target>
+</Project>

--- a/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
+++ b/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
@@ -24,12 +24,14 @@
   </ItemGroup>
 
   <Import Project="Reloaded.Trimming.targets" />
+  <Import Project="Reloaded.Checks.targets" />
 
   <ItemGroup>
     <None Remove="ModConfig.json" />
     <None Remove="Publish.ps1" />
     <None Remove="BuildLinked.ps1" />
     <None Remove="Reloaded.Trimming.targets" />
+    <None Remove="Reloaded.Checks.targets" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I had installed Reloaded-II manually which I made it not set an environment variable RELOADEDIIMODS. Because of this, when building a mod created from the template, it was copying the output to my drive root and wondering what was wrong 🙃

This PR adds a check to the csproj template to see if the environment variable is set before building and throws an error if it's not set.