### PR TITLE
Add ReleaseMetadataFileName to mod pack item

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Models/Model/Dialog/ObservablePackItem.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Models/Model/Dialog/ObservablePackItem.cs
@@ -25,6 +25,11 @@ public class ObservablePackItem : ObservableObject
     public string Summary { get; set; } = String.Empty;
 
     /// <summary>
+    /// The file name associated with the release metadata for the mod.
+    /// </summary>
+    public string ReleaseMetadataFileName { get; set; } = string.Empty;
+
+    /// <summary>
     /// List of preview image files belonging to this item.
     /// May be PNG, JPEG and JXL (JPEG XL).
     /// </summary>
@@ -64,6 +69,7 @@ public class ObservablePackItem : ObservableObject
         Name = builder.Name;
         Readme = builder.Readme;
         Summary = builder.Summary;
+        ReleaseMetadataFileName = builder.ReleaseMetadataFileName;
 
         ModId = builder.ModId;
         PluginData = builder.PluginData;
@@ -82,6 +88,7 @@ public class ObservablePackItem : ObservableObject
         itemBuilder.SetReadme(Readme);
         itemBuilder.SetPluginData(PluginData);
         itemBuilder.SetSummary(Summary);
+        itemBuilder.SetReleaseMetadataFileName(ReleaseMetadataFileName);
 
         foreach (var image in Images)
         {

--- a/source/Reloaded.Mod.Loader.Update/Packs/AutoPackCreator.cs
+++ b/source/Reloaded.Mod.Loader.Update/Packs/AutoPackCreator.cs
@@ -64,6 +64,7 @@ public static class AutoPackCreator
         var imageDownloader = new ImageCacheService();
         var itemBuilder = builder.AddModItem(config.ModId);
         itemBuilder.SetName(config.ModName);
+        itemBuilder.SetReleaseMetadataFileName(config.ReleaseMetadataFileName);
         itemBuilder.SetPluginData(config.PluginData);
 
         var bestPkg = await GetBestPackageForTemplateAsync(config.ModId, config.ModName, packageProviders, token);

--- a/source/Reloaded.Mod.Loader.Update/Packs/ReloadedPack.cs
+++ b/source/Reloaded.Mod.Loader.Update/Packs/ReloadedPack.cs
@@ -51,6 +51,11 @@ public class ReloadedPack : IConfig
             var item  = items[x];
             var slice = slicer.Slice(singleItemProgress);
             currentItemCallback?.Invoke(item);
+
+            if (updaterData.CommonPackageResolverSettings.MetadataFileName != item.ReleaseMetadataFileName)
+            {
+                updaterData.CommonPackageResolverSettings.MetadataFileName = item.ReleaseMetadataFileName;
+            }
             var downloadResult = await item.TryDownloadAsync(Path.Combine(outFolder, item.ModId), updaterData, slice, token);
             
             if (!downloadResult.Success)

--- a/source/Reloaded.Mod.Loader.Update/Packs/ReloadedPackItem.cs
+++ b/source/Reloaded.Mod.Loader.Update/Packs/ReloadedPackItem.cs
@@ -24,11 +24,16 @@ public class ReloadedPackItem
     /// Short description of the mod. 1 sentence.
     /// </summary>
     public string Summary { get; set; } = String.Empty;
-    
+
     /// <summary>
     /// Readme for this mod, in markdown format.
     /// </summary>
     public string Readme { get; set; } = String.Empty;
+
+    /// <summary>
+    /// The file name associated with the release metadata for the mod.
+    /// </summary>
+    public string ReleaseMetadataFileName { get; set; } = String.Empty;
 
     /// <summary>
     /// List of preview image files belonging to this item.
@@ -55,7 +60,8 @@ public class ReloadedPackItem
         var mod = new PathTuple<ModConfig>(Path.Combine(outFolder, ModConfig.ConfigFileName), new ModConfig()
         {
             ModId = ModId,
-            PluginData = PluginData
+            PluginData = PluginData,
+            ReleaseMetadataFileName = ReleaseMetadataFileName,
         });
         
         try

--- a/source/Reloaded.Mod.Loader.Update/Packs/ReloadedPackItemBuilder.cs
+++ b/source/Reloaded.Mod.Loader.Update/Packs/ReloadedPackItemBuilder.cs
@@ -26,6 +26,11 @@ public class ReloadedPackItemBuilder
     public string Summary { get; private set; } = string.Empty;
 
     /// <summary>
+    /// The file name associated with the release metadata for the mod.
+    /// </summary>
+    public string ReleaseMetadataFileName { get; set; } = string.Empty;
+
+    /// <summary>
     /// List of images held by this item builder.
     /// </summary>
     public Dictionary<string, object> PluginData { get; private set; } = new();
@@ -63,7 +68,7 @@ public class ReloadedPackItemBuilder
         Readme = readme;
         return this;
     }
-    
+
     /// <summary>
     /// Sets the summary (1 line) for this pack item.
     /// </summary>
@@ -72,7 +77,16 @@ public class ReloadedPackItemBuilder
         Summary = summary;
         return this;
     }
-    
+
+    /// <summary>
+    /// Sets the file name associated with the release metadata for the mod.
+    /// </summary>
+    public ReloadedPackItemBuilder SetReleaseMetadataFileName(string releaseMetadataFileName)
+    {
+        ReleaseMetadataFileName = releaseMetadataFileName;
+        return this;
+    }
+
     /// <summary>
     /// Sets the plugin data for this package item.
     /// This is usually just copied from <see cref="ModConfig.PluginData"/>.
@@ -103,6 +117,7 @@ public class ReloadedPackItemBuilder
         item.Readme = Readme;
         item.ModId = ModId;
         item.Summary = Summary;
+        item.ReleaseMetadataFileName = ReleaseMetadataFileName;
         item.PluginData = PluginData;
         
         // Pack images.


### PR DESCRIPTION
Previously if a repo uses the multirelease scheme, then the test mod pack feature would fail due to defaulting to the RMFN for the default repo. This change adds this field onto the mod pack item and uses that for configuring the download location.

Reproduction steps for the bug:

Setup a github release with custom release metadata filename
Configure mod to use this release filename
Add mod to mod pack
Use the test mod pack button.

Result: A warning pops up claiming that update support isn't setup correctly or a release is missing because Reloaded-II is using `Sewer56.Update.ReleaseMetadata.json` by default.