### PR TITLE
Update Reloaded.Mod.Interfaces version number

### DIFF
--- a/source/Reloaded.Mod.Interfaces/Reloaded.Mod.Interfaces.csproj
+++ b/source/Reloaded.Mod.Interfaces/Reloaded.Mod.Interfaces.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Reloaded-Project/Reloaded-II</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Platforms>AnyCPU</Platforms>
     <NoWarn>1701;1702;1591</NoWarn>

--- a/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
+++ b/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.3.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
   </ItemGroup>
 

--- a/source/Testing/Mods/TestModControlParams/TestModControlParams.csproj
+++ b/source/Testing/Mods/TestModControlParams/TestModControlParams.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.3.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes an issue where new projects using the latest template canont use the new control params since the latest release didn't update the Interfaces.dll

I think this should be enough, but I'm not exactly sure how to test with the current release process. It might be worth doing a quick bug fix with this update ^^; Sorry for the trouble. I think you'll also need to publish the Interface mod to nuget, as the test cases are failing without it on nuget.