### PR TITLE
Add missing using in template

### DIFF
--- a/source/Reloaded.Mod.Template/templates/configurable/Config.cs
+++ b/source/Reloaded.Mod.Template/templates/configurable/Config.cs
@@ -1,6 +1,7 @@
 ﻿#if (IncludeConfig)
 using System.ComponentModel;
 using Reloaded.Mod.Template.Template.Configuration;
+using Reloaded.Mod.Interfaces.Structs;
 
 namespace Reloaded.Mod.Template.Configuration;
 


### PR DESCRIPTION
The template fails to compile without this reference for the new Control fields.