### PR TITLE
Change exception handler to syncronous call

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Utility/ApplicationInjector.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Utility/ApplicationInjector.cs
@@ -62,7 +62,7 @@ public class ApplicationInjector
         }
         catch (Exception e)
         {
-            ActionWrappers.ExecuteWithApplicationDispatcherAsync(() =>
+            ActionWrappers.ExecuteWithApplicationDispatcher(() =>
             {
                 Errors.HandleException(new Exception(Resources.ErrorFailedToObtainPort.Get(), e));
             });


### PR DESCRIPTION
Sorry this took so long.
Finally got around to making the simple change and testing it.

Tests:
Made a simple mod which has a 40s delay in loading artificially.
Before change: Message would appear, but game would still load before message disappeared by pressing OK.
After change: Message appears and game doesn't start until OK has been pressed.