### PR TITLE
Add text format attribute for mod configs

### DIFF
--- a/source/Reloaded.Mod.Interfaces/Structs/ControlAttribute.cs
+++ b/source/Reloaded.Mod.Interfaces/Structs/ControlAttribute.cs
@@ -60,6 +60,11 @@ public class SliderControlParamsAttribute : Attribute, ICustomControlAttribute
     /// any characters that do NOT match it.
     /// </summary>
     public string TextValidationRegex { get; }
+    /// <summary>
+    /// If the text field is visible, apply this format string to the contents. This is recommended for
+    /// non-integral sliders otherwise the slider can behave erratically.
+    /// </summary>
+    public string TextFieldFormat { get; }
 
     public SliderControlParamsAttribute(
         double minimum = 0.0,
@@ -71,7 +76,8 @@ public class SliderControlParamsAttribute : Attribute, ICustomControlAttribute
         SliderControlTickPlacement tickPlacement = SliderControlTickPlacement.None,
         bool showTextField = false,
         bool isTextFieldEditable = true,
-        string textValidationRegex = ".*"
+        string textValidationRegex = ".*",
+        string textFieldFormat = ""
     ) {
         Minimum = minimum;
         Maximum = maximum;
@@ -83,6 +89,7 @@ public class SliderControlParamsAttribute : Attribute, ICustomControlAttribute
         ShowTextField = showTextField;
         IsTextFieldEditable = isTextFieldEditable;
         TextValidationRegex = textValidationRegex;
+        TextFieldFormat = textFieldFormat;
     }
 }
 

--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -470,7 +470,8 @@ public class SliderPropertyEditor : PropertyEditorBase
                 Source = _slider,
                 Path = new PropertyPath("Value"),
                 Mode = BindingMode.TwoWay,
-                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+                StringFormat = SliderControlParams.TextFieldFormat ?? ""
             });
             if (SliderControlParams.TextValidationRegex != null)
             {

--- a/source/Testing/Mods/TestModControlParams/Config.cs
+++ b/source/Testing/Mods/TestModControlParams/Config.cs
@@ -25,7 +25,7 @@ namespace TestModControlParams.Configuration
         [DisplayName("Double Slider")]
         [Description("This is a double that uses a slider control without any frills.")]
         [DefaultValue(0.5)]
-        [SliderControlParams(minimum: 0.0, maximum: 1.0)]
+        [SliderControlParams(minimum: 0.0, maximum: 1.0, showTextField: true, textFieldFormat: "{0:#,0.000}")]
         public double DoubleSlider { get; set; } = 0.5;
 
         [DisplayName("File Picker")]


### PR DESCRIPTION
Previously for sliders with `double` data type, if you displayed the label it would fluctuate in size wildly because it would show the full un-formatted value.
I have added an extra option so that you can provide a format string.
This makes them much more stable:

![image](https://github.com/Reloaded-Project/Reloaded-II/assets/8000597/04f695ee-f65f-4b3a-87d4-cd11072030ed)

I also tried to make the tooltips a bit nicer by adding a delay to the display, but it didn't really seem to do anything. It's a bit annoying IMO having them over the cursor the whole time while you are trying to drag it as you can't see what the value is while dragging. If you have any suggestions on this I'd appreciate it. I tried a few things but nothing stuck...