### PR TITLE
Draft: Increase Scrollbar Width

### DIFF
--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ApplicationSubPages/AppSummaryPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ApplicationSubPages/AppSummaryPage.xaml
@@ -126,6 +126,11 @@
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
+                <ListView.Resources>
+                    <Style TargetType="ScrollBar">
+                        <Setter Property="Width" Value="50"/>
+                    </Style>
+                </ListView.Resources>
             </ListView>
         </Grid>
 

--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ManageModsPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ManageModsPage.xaml
@@ -187,6 +187,11 @@
                                     <TextBlock Text="{Binding Config.ModName}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="{DynamicResource ListEntryItemMarginSmall}"/>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
+                            <ListView.Resources>
+                                <Style TargetType="ScrollBar">
+                                    <Setter Property="Width" Value="50"/>
+                                </Style>
+                            </ListView.Resources>
                         </ListView>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
EXTRA THICC scrollbars (do not merge - for dream use only until properly in styles as a config override)

Opening a PR so I don't forget about this.
I'll be using this fork in the interim for my own usage of R-II.
In day to day use on devices without scroll capability (TV setup), Reloaded-II scrollbars are much too thin especially with 300% Scaling (common with windows->TV setup).

If current style options allow overwriting via a new theme, that is great.
However the default size should have more width as its very hard to click on it even on normal monitor.

--
![ex-gamepicker](https://github.com/Reloaded-Project/Reloaded-II/assets/14857235/1b8deafa-c4d9-4ba6-8267-585ca4ca044e)
![manage-mods](https://github.com/Reloaded-Project/Reloaded-II/assets/14857235/63a97154-218a-479e-9660-82ee084d43d1)
