### PR TITLE
Make steam hook work with Unreal Engine games

### DIFF
--- a/source/Reloaded.Mod.Loader/Utilities/Steam/SteamHook.cs
+++ b/source/Reloaded.Mod.Loader/Utilities/Steam/SteamHook.cs
@@ -22,7 +22,7 @@ public class SteamHook
     {
         _applicationFolder = applicationFolder;
         var steamApiPath = Environment.Is64BitProcess ? Path.GetFullPath(SteamAPI64) : Path.GetFullPath(SteamAPI32);
-        if (!File.Exists(steamApiPath))
+        if (!File.Exists(steamApiPath) && !TryFindUnrealSteamApi(out steamApiPath))
             return;
 
         // Hook relevant functions
@@ -46,6 +46,19 @@ public class SteamHook
             logger.SteamWriteLineAsync($"{functionName} hooked successfully.", logger.ColorSuccess);
             return hooks.CreateHook<T>(handler, (long)functionPtr).Activate();
         }
+    }
+
+    private bool TryFindUnrealSteamApi(out string steamApiPath)
+    {
+        steamApiPath = null;
+        
+        // Assuming consistent folder structure is used for Unreal Engine games
+        var steamWorksPath = Path.Combine(_applicationFolder, @"..\..\..\Engine\Binaries\ThirdParty\SteamWorks");
+        if (!Directory.Exists(steamWorksPath))
+            return false;
+        
+        steamApiPath = Directory.EnumerateFiles(steamWorksPath, "steam_api??.dll", SearchOption.AllDirectories).FirstOrDefault();
+        return steamApiPath != null;
     }
 
     private void DropSteamAppId(Logger logger)

--- a/source/Reloaded.Mod.Loader/Utilities/Steam/SteamHook.cs
+++ b/source/Reloaded.Mod.Loader/Utilities/Steam/SteamHook.cs
@@ -48,6 +48,7 @@ public class SteamHook
         }
     }
 
+    // This is a hack and only applies to UE4 games (leaving as is until R3)
     private bool TryFindUnrealSteamApi(out string steamApiPath)
     {
         steamApiPath = null;


### PR DESCRIPTION
Unreal Engine games have the steam api dll in a different folder from the game's exe so Steam Hook didn't work. This pr makes Reloaded attempt to search in the correct place for UE games, letting steam hook work with them. 

As far as I can tell the folder structure is always consistent for UE games so this should work with any (hopefully I'm correct :D)