### PR TITLE
Support mod subdirectories

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Usings.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Usings.cs
@@ -8,7 +8,6 @@ global using NuGet.Versioning;
 global using Octokit;
 global using Ookii.Dialogs.Wpf;
 global using PropertyChanged;
-global using Reloaded.Memory.Sources;
 global using Reloaded.Mod.Interfaces;
 global using Reloaded.Mod.Launcher.Lib.Commands.Application;
 global using Reloaded.Mod.Launcher.Lib.Commands.Download;

--- a/source/Reloaded.Mod.Launcher/Misc/Imaging.cs
+++ b/source/Reloaded.Mod.Launcher/Misc/Imaging.cs
@@ -1,3 +1,4 @@
+using Reloaded.Memory.Extensions;
 using Image = System.Drawing.Image;
 using Rectangle = System.Drawing.Rectangle;
 
@@ -91,7 +92,7 @@ public class Imaging
     /// </summary>
     /// <param name="inputBitmap">The input image.</param>
     /// <param name="output">The output stream.</param>
-    public static bool TryConvertToIcon(Bitmap inputBitmap, Stream output)
+    public unsafe static bool TryConvertToIcon(Bitmap inputBitmap, Stream output)
     {
         if (inputBitmap == null)
             return false;
@@ -111,7 +112,7 @@ public class Imaging
             streams.Add(imageStream);
         }
 
-        using var iconWriter = new ExtendedMemoryStream();
+        using var iconWriter = new MemoryStream();
             
         // Write ICO header.
         iconWriter.Write(new IcoHeader()
@@ -121,7 +122,7 @@ public class Imaging
         });
 
         // Make Image Headers
-        var imageDataOffset = Struct.GetSize<IcoHeader>() + (Struct.GetSize<IcoEntry>() * sizes.Length);
+        var imageDataOffset = sizeof(IcoHeader) + (sizeof(IcoEntry) * sizes.Length);
         for (int x = 0; x < sizes.Length; x++)
         {
             iconWriter.Write(new IcoEntry()

--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ApplicationSubPages/AppSummaryPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ApplicationSubPages/AppSummaryPage.xaml
@@ -106,7 +106,7 @@
                                       Focusable="False"
                                       IsThreeState="False" />
 
-                            <TextBlock Text="{Binding Tuple.Config.ModNameDisplay, UpdateSourceTrigger=PropertyChanged}" 
+                            <TextBlock Text="{Binding Tuple.Config.ModDisplayName, UpdateSourceTrigger=PropertyChanged}" 
                                        VerticalAlignment="Center" 
                                        HorizontalAlignment="Left" 
                                        Margin="{DynamicResource ListEntryItemMarginSmall}"

--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ApplicationSubPages/AppSummaryPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ApplicationSubPages/AppSummaryPage.xaml
@@ -106,7 +106,7 @@
                                       Focusable="False"
                                       IsThreeState="False" />
 
-                            <TextBlock Text="{Binding Tuple.Config.ModName, UpdateSourceTrigger=PropertyChanged}" 
+                            <TextBlock Text="{Binding Tuple.Config.ModNameDisplay, UpdateSourceTrigger=PropertyChanged}" 
                                        VerticalAlignment="Center" 
                                        HorizontalAlignment="Left" 
                                        Margin="{DynamicResource ListEntryItemMarginSmall}"

--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ManageModsPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ManageModsPage.xaml
@@ -21,7 +21,7 @@
             <!-- Sort the mod list -->
             <CollectionViewSource x:Key="SortedMods" Source="{Binding ModConfigService.Items, UpdateSourceTrigger=PropertyChanged}" IsLiveSortingRequested="True" IsLiveFilteringRequested="True">
                 <CollectionViewSource.SortDescriptions>
-                    <componentModel:SortDescription PropertyName="Config.ModName"/>
+                    <componentModel:SortDescription PropertyName="Config.ModNameDisplay" />
                 </CollectionViewSource.SortDescriptions>
             </CollectionViewSource>
 
@@ -184,7 +184,7 @@
                             VerticalContentAlignment="Top">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding Config.ModName}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="{DynamicResource ListEntryItemMarginSmall}"/>
+                                    <TextBlock Text="{Binding Config.ModNameDisplay}"  VerticalAlignment="Center" HorizontalAlignment="Center" Margin="{DynamicResource ListEntryItemMarginSmall}"/>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>

--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ManageModsPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/ManageModsPage.xaml
@@ -21,7 +21,7 @@
             <!-- Sort the mod list -->
             <CollectionViewSource x:Key="SortedMods" Source="{Binding ModConfigService.Items, UpdateSourceTrigger=PropertyChanged}" IsLiveSortingRequested="True" IsLiveFilteringRequested="True">
                 <CollectionViewSource.SortDescriptions>
-                    <componentModel:SortDescription PropertyName="Config.ModNameDisplay" />
+                    <componentModel:SortDescription PropertyName="Config.ModDisplayName" />
                 </CollectionViewSource.SortDescriptions>
             </CollectionViewSource>
 
@@ -184,7 +184,7 @@
                             VerticalContentAlignment="Top">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding Config.ModNameDisplay}"  VerticalAlignment="Center" HorizontalAlignment="Center" Margin="{DynamicResource ListEntryItemMarginSmall}"/>
+                                    <TextBlock Text="{Binding Config.ModDisplayName}"  VerticalAlignment="Center" HorizontalAlignment="Center" Margin="{DynamicResource ListEntryItemMarginSmall}"/>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>

--- a/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
+++ b/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
@@ -75,7 +75,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Reloaded.Input" Version="2.2.0" />
-    <PackageReference Include="Reloaded.Memory" Version="7.0.0" />
+    <PackageReference Include="Reloaded.Memory" Version="9.4.0" />
     <PackageReference Include="Reloaded.WPF" Version="3.3.0" />
     <PackageReference Include="Reloaded.WPF.Theme.Default" Version="3.2.1" />
     <PackageReference Include="Sewer56.UI.Controller.Core" Version="1.1.0" />

--- a/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
+++ b/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
@@ -265,7 +265,7 @@ public class ModConfig : ObservableObject, IConfig<ModConfig>, IModConfig
         if (modDirectory == null)
             modDirectory = IConfig<LoaderConfig>.FromPathOrDefault(Paths.LoaderConfigPath).GetModConfigDirectory();
 
-        var modConfigs = ConfigReader<ModConfig>.ReadConfigurations(modDirectory, ConfigFileName, token, int.MaxValue, 2);
+        var modConfigs = ConfigReader<ModConfig>.ReadConfigurations(modDirectory, ConfigFileName, token, int.MaxValue, 2).GroupBy(x => x.Config.ModId).Select(x => x.First()).ToList();
         foreach (var cfg in modConfigs)
         {
             cfg.Config.RefreshSubdirectoryPaths(modDirectory, cfg.Path);

--- a/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
+++ b/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
@@ -249,7 +249,7 @@ public class ModConfig : ObservableObject, IConfig<ModConfig>, IModConfig
         if (modDirectory == null)
             modDirectory = IConfig<LoaderConfig>.FromPathOrDefault(Paths.LoaderConfigPath).GetModConfigDirectory();
 
-        return ConfigReader<ModConfig>.ReadConfigurations(modDirectory, ConfigFileName, token, 2, 2);
+        return ConfigReader<ModConfig>.ReadConfigurations(modDirectory, ConfigFileName, token, int.MaxValue, 2);
     }
 
     /// <summary>

--- a/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
+++ b/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
@@ -121,6 +121,16 @@ public class ModConfig : ObservableObject, IConfig<ModConfig>, IModConfig
         return HasDllPath(this);
     }
 
+    /// <summary>
+    /// Refresh the sub directories of the mod, and by extension also the Mod Display Name.
+    /// </summary>
+    public void RefreshSubdirectoryPaths(string configDirectory, string modPath)
+    {
+        var relativePath = Path.GetRelativePath(configDirectory, modPath);
+        var subDirectories = relativePath.Split(Path.DirectorySeparatorChar)[..^2];
+        ModSubDirs = subDirectories;
+    }
+
     /*
        ---------
        Utilities
@@ -255,7 +265,13 @@ public class ModConfig : ObservableObject, IConfig<ModConfig>, IModConfig
         if (modDirectory == null)
             modDirectory = IConfig<LoaderConfig>.FromPathOrDefault(Paths.LoaderConfigPath).GetModConfigDirectory();
 
-        return ConfigReader<ModConfig>.ReadConfigurations(modDirectory, ConfigFileName, token, int.MaxValue, 2);
+        var modConfigs = ConfigReader<ModConfig>.ReadConfigurations(modDirectory, ConfigFileName, token, int.MaxValue, 2);
+        foreach (var cfg in modConfigs)
+        {
+            cfg.Config.RefreshSubdirectoryPaths(modDirectory, cfg.Path);
+        }
+
+        return modConfigs;
     }
 
     /// <summary>

--- a/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
+++ b/source/Reloaded.Mod.Loader.IO/Config/ModConfig.cs
@@ -34,6 +34,12 @@ public class ModConfig : ObservableObject, IConfig<ModConfig>, IModConfig
     public bool   IsLibrary         { get; set; } = false;
     public string ReleaseMetadataFileName { get; set; } = "Sewer56.Update.ReleaseMetadata.json";
 
+    [JsonIgnore]
+    public string[] ModSubDirs { get; set; } = [];
+
+    [JsonIgnore]
+    public string ModNameDisplay => !ModSubDirs.Any() ? ModName : $"{string.Join(" - ", ModSubDirs)} - {ModName}";
+
     /// <summary>
     /// Data stored by plugins. Maps a unique string key to arbitrary data.
     /// </summary>

--- a/source/Reloaded.Mod.Loader.IO/ConfigReader.cs
+++ b/source/Reloaded.Mod.Loader.IO/ConfigReader.cs
@@ -20,11 +20,12 @@ public static class ConfigReader<TConfigType> where TConfigType : IConfig<TConfi
     /// <param name="token">Cancels the task if necessary.</param>
     /// <param name="maxDepth">Maximum depth (inclusive) in directories to get files from where 1 is only this directory.</param>
     /// <param name="minDepth">Minimum depth (inclusive) in directories to get files from where 1 is this directory.</param>
+    /// <param name="recurseOnFound">Continues to search in subdirectories even if <see cref="fileName"/> is found.</param>
     /// <returns>Tuples containing the path the configurations was loaded from and the corresponding config class.</returns>
-    public static List<PathTuple<TConfigType>> ReadConfigurations(string directory, string fileName, CancellationToken token = default, int maxDepth = 1, int minDepth = 1)
+    public static List<PathTuple<TConfigType>> ReadConfigurations(string directory, string fileName, CancellationToken token = default, int maxDepth = 1, int minDepth = 1, bool recurseOnFound = true)
     {
         // Get all config files to load.
-        var configurationPaths = Utility.IOEx.GetFilesEx(directory, fileName, maxDepth, minDepth);
+        var configurationPaths = IOEx.GetFilesEx(directory, fileName, maxDepth, minDepth, recurseOnFound);
 
         // Configurations to be returned
         var configurations = new List<PathTuple<TConfigType>>(configurationPaths.Count);

--- a/source/Reloaded.Mod.Loader.IO/Reloaded.Mod.Loader.IO.csproj
+++ b/source/Reloaded.Mod.Loader.IO/Reloaded.Mod.Loader.IO.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Reloaded.Memory" Version="7.0.0" />
+    <PackageReference Include="Reloaded.Memory" Version="9.4.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.0-rc.2.22472.3" Condition="'$(TargetFramework)' == 'net5.0'" />
   </ItemGroup>
 

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -169,12 +169,22 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
             return;
         }
         
+        // We need paths with trailing slashes in the case of:
+        // - Mod A/ModZ
+        // - Mod A Extra/ModZ
+        // We don't want to match 'Mod A Extra' when we're looking for 'Mod A'.
+        if (!Path.EndsInDirectorySeparator(deletedPath))
+            deletedPath += Path.DirectorySeparatorChar;
+        
         // Otherwise iterate over all possible subfolders.
         // This is a bit inefficient, but with nested mods, it's the only way (without creating a whole tree of nodes).
         // Can rack up upwards of 20ms in huge mod directories.
         foreach (var item in ItemsByFolder)
         {
             var modFolder = item.Key;
+            if (!Path.EndsInDirectorySeparator(modFolder))
+                modFolder += Path.DirectorySeparatorChar;
+            
             var shouldRemove = modFolder.StartsWith(deletedPath, StringComparison.OrdinalIgnoreCase);
             if (shouldRemove)
             { 
@@ -247,8 +257,20 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
 
     private bool IsFileInItemFolder(string filePath)
     {
+        var cfgPath = ConfigDirectory;
         var pathContainingFolder = Path.GetDirectoryName(Path.GetDirectoryName(filePath));
-        return pathContainingFolder.StartsWith(ConfigDirectory, StringComparison.OrdinalIgnoreCase);
+
+        // We need paths with trailing slashes in the case of:
+        // - Mod A/ModZ
+        // - Mod A Extra/ModZ
+        // We don't want to match 'Mod A Extra' when we're looking for 'Mod A'.
+        if (!Path.EndsInDirectorySeparator(cfgPath))
+            cfgPath += Path.DirectorySeparatorChar;
+
+        if (!Path.EndsInDirectorySeparator(pathContainingFolder))
+            pathContainingFolder += Path.DirectorySeparatorChar;
+
+        return pathContainingFolder.StartsWith(cfgPath, StringComparison.OrdinalIgnoreCase);
     }
 
     private bool IsFileConfigFile(string filePath)

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -209,8 +209,21 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
 
     private bool IsFileInItemFolder(string filePath)
     {
+        var cfgPath = ConfigDirectory;
         var pathContainingFolder = Path.GetDirectoryName(Path.GetDirectoryName(filePath));
-        return pathContainingFolder.Equals(ConfigDirectory, StringComparison.OrdinalIgnoreCase);
+
+        // Get paths with a trailing slash so that the Contains call will work correctly for mods in subdirectories.
+        if (!Path.EndsInDirectorySeparator(cfgPath))
+        {
+            cfgPath += Path.DirectorySeparatorChar;
+        }
+
+        if (!Path.EndsInDirectorySeparator(pathContainingFolder))
+        {
+            pathContainingFolder += Path.DirectorySeparatorChar;
+        }
+
+        return pathContainingFolder.Contains(cfgPath, StringComparison.OrdinalIgnoreCase);
     }
 
     private bool IsFileConfigFile(string filePath)

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -59,11 +59,11 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
         ItemFileName    = itemFileName;
         _getAllConfigs  = getAllConfigs;
         _renameWatcher          = Create(ConfigDirectory, null, OnRename, FileSystemWatcherEvents.Renamed, true, "*.json", useBigBuffers);
-        _createFolderWatcher    = Create(ConfigDirectory, OnCreateFolder, null, FileSystemWatcherEvents.Created, false, "*.*", useBigBuffers);
+        _createFolderWatcher    = Create(ConfigDirectory, OnCreateFolder, null, FileSystemWatcherEvents.Created, true, "*.*", useBigBuffers);
         _createFileWatcher      = Create(ConfigDirectory, OnCreateFile, null, FileSystemWatcherEvents.Created, true, "*.json", useBigBuffers);
         _changedWatcher         = Create(ConfigDirectory, OnUpdateFile, null, FileSystemWatcherEvents.Changed, true, "*.json", useBigBuffers);
-        _deleteFileWatcher      = Create(ConfigDirectory, OnDeleteFile, null, FileSystemWatcherEvents.Deleted, useBigBuffers);
-        _deleteDirectoryWatcher = Create(ConfigDirectory, OnDeleteDirectory, null, FileSystemWatcherEvents.Deleted, false, "*.*", useBigBuffers);
+        _deleteFileWatcher      = Create(ConfigDirectory, OnDeleteFile, null, FileSystemWatcherEvents.Deleted, true, useBigBuffers: useBigBuffers);
+        _deleteDirectoryWatcher = Create(ConfigDirectory, OnDeleteDirectory, null, FileSystemWatcherEvents.Deleted, true, "*.*", useBigBuffers);
         GetItems(executeImmediately);
     }
 

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -234,21 +234,8 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
 
     private bool IsFileInItemFolder(string filePath)
     {
-        var cfgPath = ConfigDirectory;
         var pathContainingFolder = Path.GetDirectoryName(Path.GetDirectoryName(filePath));
-
-        // Get paths with a trailing slash so that the Contains call will work correctly for mods in subdirectories.
-        if (!Path.EndsInDirectorySeparator(cfgPath))
-        {
-            cfgPath += Path.DirectorySeparatorChar;
-        }
-
-        if (!Path.EndsInDirectorySeparator(pathContainingFolder))
-        {
-            pathContainingFolder += Path.DirectorySeparatorChar;
-        }
-
-        return pathContainingFolder.Contains(cfgPath, StringComparison.OrdinalIgnoreCase);
+        return pathContainingFolder.StartsWith(ConfigDirectory, StringComparison.OrdinalIgnoreCase);
     }
 
     private bool IsFileConfigFile(string filePath)

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -216,7 +216,7 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
         }
     }
 
-    private void AddItem(PathTuple<TConfigType> itemTuple)
+    protected virtual void AddItem(PathTuple<TConfigType> itemTuple)
     {
         // Check for existing item.
         bool alreadyHasItem = ItemsByPath.TryGetValue(itemTuple.Path, out var existing);

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -142,7 +142,7 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
             return;
 
         // Read configurations from subdirectories within the current path.
-        var configs = ConfigReader<TConfigType>.ReadConfigurations(Path.TrimEndingDirectorySeparator(e.FullPath), ItemFileName, maxDepth: int.MaxValue);
+        var configs = ConfigReader<TConfigType>.ReadConfigurations(Path.TrimEndingDirectorySeparator(e.FullPath), ItemFileName, maxDepth: int.MaxValue, recurseOnFound: false);
         foreach (var config in configs)
         {
             _context.Post(() => AddItem(config));

--- a/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ConfigServiceBase.cs
@@ -155,22 +155,10 @@ public abstract class ConfigServiceBase<TConfigType> : ObservableObject where TC
     {
         var deletedPath = e.FullPath;
 
-        // Get paths with a trailing slash so that the Contains call will work correctly for subdirectories.
-        if (!Path.EndsInDirectorySeparator(deletedPath))
-        {
-            deletedPath += Path.DirectorySeparatorChar;
-        }
-
         // Check for mods in subdirectories.
         var deletedMods = ItemsByFolder.Where(x =>
         {
             var pathContainingFolder = x.Key;
-
-            // Get paths with a trailing slash so that the Contains call will work correctly for mods in subdirectories.
-            if (!Path.EndsInDirectorySeparator(pathContainingFolder))
-            {
-                pathContainingFolder += Path.DirectorySeparatorChar;
-            }
 
             // Check if the current path contains the deleted path, meaning that it is also deleted.
             return pathContainingFolder.Contains(deletedPath)

--- a/source/Reloaded.Mod.Loader.IO/Services/ModConfigService.cs
+++ b/source/Reloaded.Mod.Loader.IO/Services/ModConfigService.cs
@@ -71,6 +71,14 @@ public class ModConfigService : ConfigServiceBase<ModConfig>
 
     private void OnAddItemHandler(PathTuple<ModConfig> obj) => ItemsById[obj.Config.ModId] = obj;
 
+    protected override void AddItem(PathTuple<ModConfig> obj)
+    {
+        // Update the subdirectory paths before adding it to the config service collection.
+        // Required to get the display name to show up correctly after editing a mod when it's bound to the Items collection.
+        obj.Config.RefreshSubdirectoryPaths(ConfigDirectory, obj.Path);
+        base.AddItem(obj);
+    }
+
     private List<PathTuple<ModConfig>> GetAllConfigs() => ModConfig.GetAllMods(base.ConfigDirectory);
 }
 

--- a/source/Reloaded.Mod.Loader.IO/Utility/IOEx.cs
+++ b/source/Reloaded.Mod.Loader.IO/Utility/IOEx.cs
@@ -179,14 +179,15 @@ public static class IOEx
     /// <param name="fileName">The name of the file to load. The filename can contain wildcards * but not regex.</param>
     /// <param name="maxDepth">Maximum depth (inclusive) to search in with 1 indicating only current directory.</param>
     /// <param name="minDepth">Minimum depth (inclusive) to search in with 1 indicating current directory.</param>
-    public static List<string> GetFilesEx(string directory, string fileName, int maxDepth = 1, int minDepth = 1)
+    /// <param name="recurseOnFound">Continues to search in subdirectories even if <see cref="fileName"/> is found.</param>
+    public static List<string> GetFilesEx(string directory, string fileName, int maxDepth = 1, int minDepth = 1, bool recurseOnFound = true)
     {
         var files = new List<string>();
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            GetFilesExDirectories_Generic(directory, fileName, maxDepth, minDepth, 0, files);
+            GetFilesExDirectories_Generic(directory, fileName, maxDepth, minDepth, 0, files, recurseOnFound);
         else
-            GetFilesExDirectories_Windows(directory, fileName, maxDepth, minDepth, 0, files);
+            GetFilesExDirectories_Windows(directory, fileName, maxDepth, minDepth, 0, files, recurseOnFound);
 
         return files;
     }
@@ -251,19 +252,23 @@ public static class IOEx
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void GetFilesExDirectories_Windows(string directory, string fileName, int maxDepth, int minDepth, int currentDepth, List<string> files)
+    private static void GetFilesExDirectories_Windows(string directory, string fileName, int maxDepth, int minDepth, int currentDepth, List<string> files, bool recurseOnFound = false)
     {
 #pragma warning disable CA1416 // Validate platform compatibility
         var listFileInfo = new List<NtQueryDirectoryFileSearcher.FileInformation>();
         var listDirInfo = new List<NtQueryDirectoryFileSearcher.DirectoryInformation>();
-        GetFilesExDirectories_Windows_Internal(directory, fileName, maxDepth, minDepth, currentDepth, files, listFileInfo, listDirInfo);
+        GetFilesExDirectories_Windows_Internal(directory, fileName, maxDepth, minDepth, currentDepth, files, listFileInfo, listDirInfo, recurseOnFound);
 #pragma warning restore CA1416 // Validate platform compatibility
     }
 
     [SupportedOSPlatform("windows5.1.2600")]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void GetFilesExDirectories_Windows_Internal(string directory, string fileName, int maxDepth, int minDepth, int currentDepth, List<string> files, List<NtQueryDirectoryFileSearcher.FileInformation> fileInfoBuffer, List<NtQueryDirectoryFileSearcher.DirectoryInformation> dirInfoBuffer)
+    private static void GetFilesExDirectories_Windows_Internal(string directory, string fileName, int maxDepth,
+        int minDepth, int currentDepth, List<string> files,
+        List<NtQueryDirectoryFileSearcher.FileInformation> fileInfoBuffer,
+        List<NtQueryDirectoryFileSearcher.DirectoryInformation> dirInfoBuffer, bool recurseOnFound)
     {
+        var stopSearch = false;
         fileInfoBuffer.Clear();
         dirInfoBuffer.Clear();
         
@@ -274,24 +279,32 @@ public static class IOEx
             foreach (var fileInfo in fileInfoBuffer)
             {
                 if (fileInfo.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    stopSearch = !recurseOnFound;
                     files.Add(Path.Combine(fileInfo.DirectoryPath, fileInfo.FileName));
+                }
             }
         }
 
-        if (currentDepth + 1 >= maxDepth)
+        if (currentDepth + 1 >= maxDepth || stopSearch)
             return;
 
         foreach (var subdir in dirInfoBuffer.ToArray())
-            GetFilesExDirectories_Windows_Internal(subdir.FullPath, fileName, maxDepth, minDepth, currentDepth + 1, files, fileInfoBuffer, dirInfoBuffer);
+            GetFilesExDirectories_Windows_Internal(subdir.FullPath, fileName, maxDepth, minDepth, currentDepth + 1, files, fileInfoBuffer, dirInfoBuffer, recurseOnFound);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    private static void GetFilesExDirectories_Generic(string directory, string fileName, int maxDepth, int minDepth, int currentDepth, List<string> files)
+    private static void GetFilesExDirectories_Generic(string directory, string fileName, int maxDepth, int minDepth, int currentDepth, List<string> files, bool recurseOnFound = false)
     {
+        var stopSearch = false;
         if (currentDepth >= minDepth - 1 && currentDepth < maxDepth)
-            files.AddRange(GetFilesInDirectory(directory, fileName));
+        {
+            var foundFiles = GetFilesInDirectory(directory, fileName);
+            stopSearch = foundFiles.Length > 0 && !recurseOnFound;
+            files.AddRange(foundFiles);
+        }
 
-        if (currentDepth + 1 >= maxDepth) 
+        if (currentDepth + 1 >= maxDepth || stopSearch) 
             return;
 
         foreach (var subdir in Directory.GetDirectories(directory))


### PR DESCRIPTION
This adds support for reading mods in (nested) sub-directories and modifies the displayed name in the UI (limited to the `Configure Mods` and `Manage Mods` pages) with that of the directory tree, excluding the last folder that is often the mod id.

I prefer this a bit more since I am often downloading and updating mods manually, and not every mod author uses a naming convention that makes sense to me.

## Notes
* This does change the base ConfigService, so applications will also listen to changes in the sub-directories. I don't think this is a big deal really but the adjusted watchers could be moved if needed.
* Updating the new mod properties right after reading the configurations.
  * I had to override `AddItem` for this because otherwise it would mess up in the `Manage Mods` page when a mod got modified.
* I also fixed the bug you mentioned, #306.
  * (I would have liked to use `DistinctBy` but that's .net 6 and this particular library also builds on .net 5)

## Preview
![image](https://github.com/Reloaded-Project/Reloaded-II/assets/31796925/17d88c0b-7b2a-42c7-a946-a20242017ae8)
![image](https://github.com/Reloaded-Project/Reloaded-II/assets/31796925/7f678ce0-51d8-40d4-9391-19dc48b6b3c0)

The directory tree inside my `Mods` folder:
```
├───reloaded.sharedlib.hooks
├───reloaded.universal.redirector
├───Reloaded.Utils.Server
├───Something
│   └───reloaded.universal.something
└───Test
    └───Another Folder
        ├───reloaded.universal.monitor
        └───Yet Another Folder
            └───TestModControlParams
```

Moving a folder deletes all mods containing that folder, same for adding a folder with multiple mods inside it, and again works when renaming a folder. I have also not found any issues editing mods so far.

(By the way, editing a mod and closing the form always results in a save, I would have expected it to cancel. Though it did actually help me in testing.)

Let me know what you think, maybe you could do a bit of testing yourself since I only recently started using R2. No need to rush though.