### PR TITLE
Update AsiLoaderDeployer.cs

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Utility/AsiLoaderDeployer.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Utility/AsiLoaderDeployer.cs
@@ -223,9 +223,9 @@ public class AsiLoaderDeployer
     {
         "winmm.dll",
         "wininet.dll",
-        "version.dll",
         "dsound.dll",
-        "dinput8.dll"
+        "dinput8.dll",
+        "version.dll"
     };
 
     private static readonly string[] AsiCommonDirectories = 


### PR DESCRIPTION
Changed default priority/order as version.dll seemingly tends to cause issues in some games (such as bringing up the crash handler) while the others work on most games without issues. 

Making version.dll the last fallback seems the sensible choice here.