### PR TITLE
Updated: Reloaded.Mod.Template and GH Actions

### DIFF
--- a/.github/workflows/DeployMkDocs.yml
+++ b/.github/workflows/DeployMkDocs.yml
@@ -21,7 +21,7 @@ jobs:
       
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Deploy MkDocs
       - name: Deploy MkDocs

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -30,7 +30,7 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -44,7 +44,7 @@ jobs:
     
     # Required for C#10 features.
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '14'
     
@@ -58,22 +58,19 @@ jobs:
       run: npm install -g auto-changelog
    
     - name: Setup Dotnet SDK (5.0)
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '5.0.x'
-        include-prerelease: true
 
     - name: Setup Dotnet SDK (7.0)
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
 
     - name: Setup Dotnet SDK (8.0)
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
-        include-prerelease: true
     
     - name: Get Dotnet Info
       run: dotnet --info
@@ -121,7 +118,7 @@ jobs:
         }
         
     - name: Upload Chocolatey Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Chocolatey Package
@@ -130,7 +127,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Reloaded Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Loader Build
@@ -139,7 +136,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Installer Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Installer
@@ -148,7 +145,7 @@ jobs:
         retention-days: 0
          
     - name: Upload NuGet Artifacts
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: NuGet Packages
@@ -157,7 +154,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Changelog
@@ -166,7 +163,7 @@ jobs:
         retention-days: 0
     
     - name: Upload Tools Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Tools
@@ -175,7 +172,7 @@ jobs:
         retention-days: 0
     
     - name: Upload to GitHub Releases
-      uses: softprops/action-gh-release@v0.1.14
+      uses: softprops/action-gh-release@v2
       if: env.IS_RELEASE == 'true'
       with:
         # Path to load note-worthy description of changes in release from

--- a/.github/workflows/reloaded-utils-server.yml
+++ b/.github/workflows/reloaded-utils-server.yml
@@ -46,24 +46,23 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'
         
     - name: Setup .NET Core SDK (5.0)
-      uses: actions/setup-dotnet@v1.8.2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 5.0.x
         
-    - name: Setup .NET Core SDK (7.0)
-      uses: actions/setup-dotnet@v1.8.2
+    - name: Setup .NET Core SDK (8.0)
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
-        include-prerelease: true
+        dotnet-version: 8.0.x
         
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '14'
         
@@ -84,7 +83,7 @@ jobs:
       run: ./source/Mods/Reloaded.Utils.Server/Publish.ps1 -ChangelogPath "$env:PUBLISH_CHANGELOG_PATH" -BuildR2R true
       
     - name: Upload GitHub Release Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: GitHub Release
@@ -93,7 +92,7 @@ jobs:
           ${{ env.PUBLISH_GITHUB_PATH }}/*
           
     - name: Upload GameBanana Release Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: GameBanana Release
@@ -102,7 +101,7 @@ jobs:
           ${{ env.PUBLISH_GAMEBANANA_PATH }}/*
         
     - name: Upload NuGet Release Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: NuGet Release
@@ -111,7 +110,7 @@ jobs:
           ${{ env.PUBLISH_NUGET_PATH }}/*
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Changelog

--- a/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
+++ b/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>$(RELOADEDIIMODS)/Reloaded.Utils.Server</OutputPath>
@@ -49,6 +49,10 @@
     <Content Include="ModConfig.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
+++ b/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net7.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <TargetFrameworks>net5.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <NoWarn>1701;1702;CS1591;NU5104;CS0067</NoWarn>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Sewer56</Authors>
@@ -22,14 +22,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="AnyOf" Version="0.3.0" />
-    <PackageReference Include="LiteNetLib" Version="1.0.0-rc.3" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="AnyOf" Version="0.4.0" />
+    <PackageReference Include="LiteNetLib" Version="1.2.0" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Equals.Fody" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Reloaded.Messaging" Version="2.0.1" />

--- a/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
+++ b/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.6.2</PackageVersion>
+    <PackageVersion>1.6.3</PackageVersion>
     <PackageId>Reloaded.Mod.Templates</PackageId>
     <Title>Reloaded-II Mod Templates</Title>
     <Authors>Sewer56</Authors>

--- a/source/Reloaded.Mod.Template/templates/configurable/.github/workflows/reloaded.yml
+++ b/source/Reloaded.Mod.Template/templates/configurable/.github/workflows/reloaded.yml
@@ -48,23 +48,23 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'recursive'
         
     - name: Setup .NET Core SDK (5.0)
-      uses: actions/setup-dotnet@v1.8.2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 5.0.x
         
-    - name: Setup .NET Core SDK (6.0)
-      uses: actions/setup-dotnet@v1.8.2
+    - name: Setup .NET Core SDK (8.0)
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
         
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '14'
         
@@ -85,7 +85,7 @@ jobs:
       run: ./Publish.ps1 -ChangelogPath "$env:PUBLISH_CHANGELOG_PATH"
       
     - name: Upload GitHub Release Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: GitHub Release
@@ -94,7 +94,7 @@ jobs:
           ${{ env.PUBLISH_GITHUB_PATH }}/*
           
     - name: Upload GameBanana Release Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: GameBanana Release
@@ -103,7 +103,7 @@ jobs:
           ${{ env.PUBLISH_GAMEBANANA_PATH }}/*
         
     - name: Upload NuGet Release Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: NuGet Release
@@ -112,7 +112,7 @@ jobs:
           ${{ env.PUBLISH_NUGET_PATH }}/*
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Changelog
@@ -121,7 +121,7 @@ jobs:
         retention-days: 0
     
     - name: Upload to GitHub Releases (on Tag)
-      uses: softprops/action-gh-release@v0.1.14
+      uses: softprops/action-gh-release@v2
       if: env.IS_RELEASE == 'true'
       with:
         # Path to load note-worthy description of changes in release from

--- a/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
+++ b/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>$(RELOADEDIIMODS)/Reloaded.Mod.Template</OutputPath>
@@ -43,6 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
   </ItemGroup>


### PR DESCRIPTION
Upgrade Reloaded.Mod.Template
- C# Lang 10 -> 12
- NET7.0 -> NET8.0
- Add Microsoft.NET.ILLink.Tasks as dependency for .NET 8 compatibility
- Bump Template version 1.6.2 -> 1.6.3

Upgrade GH Actions
- Upgrade all Microsoft actions to v4
- Upgrade other actions to latest stable releases