### PR TITLE
Added: Static Build of Setup.exe for Linux Use

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -185,6 +185,7 @@ jobs:
           ${{ env.PUBLISH_RELEASE_FOLDER }}/*
           ${{ env.TOOLS_PATH }}
           ${{ env.PUBLISH_INSTALLER_PATH }}
+          ${{ env.PUBLISH_INSTALLER_STATIC_PATH }}
         
     - name: Upload to NuGet (on Tag)
       env: 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,6 +14,7 @@ env:
   TOOLS_PATH: ./source/Publish/Tools.zip
   PUBLISH_CHOCO_PATH: ./source/Publish/Chocolatey
   PUBLISH_INSTALLER_PATH: ./source/Publish/Installer/Setup.exe 
+  PUBLISH_INSTALLER_STATIC_PATH: ./source/Publish/Installer-Static/Setup-Linux.exe 
   PUBLISH_CHANGELOG_PATH: ./source/Publish/Changelog.md 
   PUBLISH_PACKAGES_PATH: ./source/Publish/Packages
   PUBLISH_RELEASE_FOLDER: ./source/Publish/Release
@@ -141,7 +142,9 @@ jobs:
         # Artifact name
         name: Installer
         # A file, directory or wildcard pattern that describes what to upload
-        path: ${{ env.PUBLISH_INSTALLER_PATH }}
+        path: |
+          ${{ env.PUBLISH_INSTALLER_PATH }}
+          ${{ env.PUBLISH_INSTALLER_STATIC_PATH }}
         retention-days: 0
          
     - name: Upload NuGet Artifacts

--- a/source/Publish.ps1
+++ b/source/Publish.ps1
@@ -37,7 +37,6 @@ $bootstrapperPath = "Reloaded.Mod.Loader.Bootstrapper/Reloaded.Mod.Bootstrapper.
 $installerProjectPath = "./Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj"
 $launcherProjectPath = "Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj"
 $loaderProjectPath = "Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj"
-$addressDumperProjectPath = "Reloaded.Mod.Launcher.Kernel32AddressDumper/Reloaded.Mod.Launcher.Kernel32AddressDumper.csproj"
 $templateProjectPath = "Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj"
 
 $communityProjectPath = "Tools/Reloaded.Community.Tool/Reloaded.Community.Tool.csproj"
@@ -48,6 +47,7 @@ $publisherProjectPath = "Tools/Reloaded.Publisher/Reloaded.Publisher.csproj"
 $publishDirectory = "Publish"
 $chocoPublishDirectory = "$publishDirectory/Chocolatey"
 $installerPublishDirectory = "$publishDirectory/Installer"
+$installerStaticPublishDirectory = "$publishDirectory/Installer-Static"
 $templatePublishDirectory = "$publishDirectory/ModTemplate"
 $releaseFolder = "/Release"
 $toolsReleaseFileName = "/Tools.zip"
@@ -62,7 +62,6 @@ Get-ChildItem "$chocoPath" -Include *.nupkg -Recurse -ErrorAction SilentlyContin
 
 # Build using Visual Studio
 msbuild $bootstrapperPath /p:Configuration=Release /p:Platform=x64 /p:OutDir="$loaderOutputPath"
-dotnet publish "$addressDumperProjectPath" -c Release -r win-x86 --self-contained false -o "$loaderOutputPath"
 
 # Build AnyCPU, and then copy 32-bit AppHost. 
 dotnet publish "$launcherProjectPath" -c Release --self-contained false -o "$outputPath"
@@ -78,7 +77,11 @@ dotnet publish "$publisherProjectPath" -c Release -r win-x64 --self-contained fa
 dotnet publish "$communityProjectPath" -c Release -r win-x64 --self-contained false -o "$toolsPath" /p:PublishSingleFile=true
 
 # Build Installer
-dotnet publish "$installerProjectPath" -o "$installerPublishDirectory"
+dotnet publish "$installerProjectPath" -f net472 -o "$installerPublishDirectory"
+
+# Build Installer (Static/Linux)
+dotnet publish "$installerProjectPath" -f net8.0-windows -r win-x64 /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true -o "$installerStaticPublishDirectory"
+Move-Item -Path "$installerStaticPublishDirectory/Setup.exe" -Destination "$installerStaticPublishDirectory/Setup-Linux.exe"
 
 # Build Templates
 dotnet pack "$templateProjectPath" -o "$templatePublishDirectory"

--- a/source/Reloaded.Mod.Installer/FodyWeavers.xml
+++ b/source/Reloaded.Mod.Installer/FodyWeavers.xml
@@ -1,4 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura IncludeDebugSymbols='false' />
-  <PropertyChanged/>
-</Weavers>

--- a/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
+++ b/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>NET472</TargetFramework>
+    <TargetFrameworks>NET472;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>preview</LangVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -14,6 +14,15 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <WeaverConfiguration>
+      <Weavers>
+        <Costura IncludeDebugSymbols='false' Condition="'$(TargetFramework)' == 'net472'" />
+        <PropertyChanged/>
+      </Weavers>
+    </WeaverConfiguration>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Content Include="appicon.ico" />
   </ItemGroup>
@@ -21,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="ConsoleProgressBar" Version="2.0.0" />
-    <PackageReference Include="Costura.Fody" Version="5.7.0">
+    <PackageReference Include="Costura.Fody" Condition="'$(TargetFramework)' == 'net472'" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR adds a single file, self contained distribution of setup.exe to make setup on Linux a bit easier.

![image](https://github.com/user-attachments/assets/d9c49fd4-86d1-44ed-a763-77c2344f6653)

(The EXE is unfortunately huge, WPF is not trimmable)

This allows for the installer to be used under Linux without needing to run

```
winetricks dotnet48
```

Or equivalent.