### PR TITLE
Chore: Update dependencies

### DIFF
--- a/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
+++ b/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Installer.Cli/Reloaded.Mod.Installer.Cli.csproj
+++ b/source/Reloaded.Mod.Installer.Cli/Reloaded.Mod.Installer.Cli.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
         <PackageReference Include="ConsoleProgressBar" Version="2.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/source/Reloaded.Mod.Installer.DependencyInstaller/Reloaded.Mod.Installer.DependencyInstaller.csproj
+++ b/source/Reloaded.Mod.Installer.DependencyInstaller/Reloaded.Mod.Installer.DependencyInstaller.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="NetCoreInstallChecker" Version="3.0.4" />
     <PackageReference Include="RedistributableChecker" Version="0.2.3" />
   </ItemGroup>

--- a/source/Reloaded.Mod.Installer.Lib/Reloaded.Mod.Installer.Lib.csproj
+++ b/source/Reloaded.Mod.Installer.Lib/Reloaded.Mod.Installer.Lib.csproj
@@ -23,12 +23,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+        <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>

--- a/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
+++ b/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="ConsoleProgressBar" Version="2.0.0" />
     <PackageReference Include="Costura.Fody" Condition="'$(TargetFramework)' == 'net472'" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
@@ -44,7 +44,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/source/Reloaded.Mod.Launcher.Lib/Reloaded.Mod.Launcher.Lib.csproj
+++ b/source/Reloaded.Mod.Launcher.Lib/Reloaded.Mod.Launcher.Lib.csproj
@@ -13,12 +13,12 @@
 
   <ItemGroup>
     <PackageReference Include="dll_syringe.Net.Sys" Version="0.16.0" />
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="IoC.Container" Version="1.3.8" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0-beta.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="PhotoSauce.NativeCodecs.Libjxl" Version="0.6.1-ci222723" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Management" Version="6.0.0" />

--- a/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
+++ b/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
@@ -65,14 +65,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
     <PackageReference Include="HandyControl" Version="3.2.0-reloaded-1.1.0" />
     <PackageReference Include="HandyControl.Lang.en" Version="3.3.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />
     <PackageReference Include="Ninject" Version="3.3.6" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Reloaded.Input" Version="2.2.0" />

--- a/source/Reloaded.Mod.Loader.Community/Reloaded.Mod.Loader.Community.csproj
+++ b/source/Reloaded.Mod.Loader.Community/Reloaded.Mod.Loader.Community.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="Standart.Hash.xxHash" Version="3.1.0" />
   </ItemGroup>
 

--- a/source/Reloaded.Mod.Loader.IO/Reloaded.Mod.Loader.IO.csproj
+++ b/source/Reloaded.Mod.Loader.IO/Reloaded.Mod.Loader.IO.csproj
@@ -22,15 +22,15 @@
   </PropertyGroup>
 	
   <ItemGroup>
-	<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+	<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="Equals.Fody" Version="4.0.2">
 	  <PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
+++ b/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
@@ -23,13 +23,13 @@
 
   <ItemGroup>
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
-    <PackageReference Include="AnyOf" Version="0.4.0" />
-    <PackageReference Include="LiteNetLib" Version="1.2.0" />
+    <PackageReference Include="AnyOf" Version="0.5.0" />
+    <PackageReference Include="LiteNetLib" Version="1.3.1" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Equals.Fody" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.11" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Reloaded.Mod.Loader.Update.Packaging/Reloaded.Mod.Loader.Update.Packaging.csproj
+++ b/source/Reloaded.Mod.Loader.Update.Packaging/Reloaded.Mod.Loader.Update.Packaging.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="Sewer56.Update" Version="4.0.2" />
     <PackageReference Include="Sewer56.Update.Extractors.SevenZipSharp" Version="1.1.4" GeneratePathProperty="true" />
     <PackageReference Include="Sewer56.Update.Packaging" Version="3.0.1" />

--- a/source/Reloaded.Mod.Loader.Update/Reloaded.Mod.Loader.Update.csproj
+++ b/source/Reloaded.Mod.Loader.Update/Reloaded.Mod.Loader.Update.csproj
@@ -25,15 +25,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="DeepCloner" Version="0.10.4" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.66" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="NetCoreInstallChecker" Version="3.0.4" />
     <PackageReference Include="NuGet.Packaging" Version="6.11.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.7.1" />
     <PackageReference Include="Polly" Version="8.4.2" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.1">
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Equals.Fody" Version="4.0.2">
@@ -44,7 +44,7 @@
     <PackageReference Include="Sewer56.Update" Version="4.0.2" />
     <PackageReference Include="Sewer56.Update.Misc" Version="1.1.0" />
     <PackageReference Include="Sewer56.Update.Resolvers.GitHub" Version="1.5.2" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/source/Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj
+++ b/source/Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj
@@ -89,11 +89,11 @@
     <ProjectReference Include="..\Reloaded.Mod.Loader.IO\Reloaded.Mod.Loader.IO.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
     <PackageReference Include="Colorful.Console" Version="1.2.2-reloaded" />
     <PackageReference Include="Indieteur.SteamAppsManAndVDFAPI" Version="1.0.5" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0-beta.0" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.11" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" ExcludeAssets="runtime" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
+++ b/source/Reloaded.Mod.Template/templates/configurable/Reloaded.Mod.Template.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.11" />
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
   </ItemGroup>

--- a/source/Tools/Reloaded.AutoIndexBuilder/Reloaded.AutoIndexBuilder.csproj
+++ b/source/Tools/Reloaded.AutoIndexBuilder/Reloaded.AutoIndexBuilder.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.7.2" />
-    <PackageReference Include="FluentValidation" Version="11.2.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Quartz" Version="3.4.0" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.4.0" />
     <PackageReference Include="Serilog" Version="2.11.0" />

--- a/source/Tools/Reloaded.Publisher/Reloaded.Publisher.csproj
+++ b/source/Tools/Reloaded.Publisher/Reloaded.Publisher.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="FluentValidation" Version="11.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Makes this PR obsolete:
https://github.com/Reloaded-Project/Reloaded-II/pull/472

```
--Reloaded.Utils.Server--
Microsoft.NET.ILLink.Tasks 8.0.8 -> 8.0.11

--Reloaded.Mod.Installer.Cli--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25

--Reloaded.Mod.Installer.DependencyInstaller--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25

--Reloaded.Mod.Installer.Lib--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
PropertyChanged.Fody 3.4.1 -> 4.1.0

--Reloaded.Mod.Installer--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
PropertyChanged.Fody 3.4.1 -> 4.1.0

--Reloaded.Mod.Launcher.Lib--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
PropertyChanged.Fody 3.4.1 -> 4.1.0

--Reloaded.Mod.Launcher--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
gong-wpf-dragdrop 3.1.1 -> 3.2.1
PropertyChanged.Fody 3.4.1 -> 4.1.0

--Reloaded.Mod.Loader.Community--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25

--Reloaded.Mod.Loader.IO--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
PropertyChanged.Fody 3.4.1 -> 4.1.0
System.Text.Json 8.0.4 -> 9.0.0

--Reloaded.Mod.Loader.Server--
AnyOf 0.4.0 -> 0.5.0
LiteNetLib 1.2.0 -> 1.3.1
Microsoft.NET.ILLink.Tasks 8.0.8 -> 8.0.11

--Reloaded.Mod.Loader.Update.Packaging--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25

--Reloaded.Mod.Loader.Update--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
HtmlAgilityPack 1.11.66 -> 1.11.71
PropertyChanged.Fody 3.4.1 -> 4.1.0
System.Formats.Asn1 8.0.1 -> 9.0.0

--Reloaded.Mod.Loader--
DotNet.ReproducibleBuilds 1.1.1 -> 1.2.25
Microsoft.NET.ILLink.Tasks 8.0.8 -> 8.0.11

--Reloaded.Mod.Template--
Microsoft.NET.ILLink.Tasks 8.0.8 -> 8.0.11

--Reloaded.AutoIndexBuilder--
FluentValidation 11.1.0 -> 11.11.0
LibGit2Sharp 0.27.2 -> 0.30.0
MediatR.Extensions.Microsoft.DependencyInjection 10.0.1 -> REPLACED (deprecated) with MediatR 12.4.1
MediatR 12.4.1 ADDED
Microsoft.Extensions.DependencyInjection 6.0.0 -> 9.0.0

--Reloaded.Publisher--
FluentValidation 11.1.0 -> 11.11.0
```