### PR TITLE
Enhancement: Confirm dialog for Mod Delete

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Commands/Mod/DeleteModCommand.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Commands/Mod/DeleteModCommand.cs
@@ -20,7 +20,15 @@ public class DeleteModCommand : WithCanExecuteChanged, ICommand
     /// <inheritdoc />
     public void Execute(object? parameter)
     {
-        // Delete folder contents.
+        var deleteConfirm = Actions.DisplayMessagebox.Invoke(Resources.DeleteModDialogTitle.Get(), string.Format(Resources.DeleteModDialogDescription.Get(), _modTuple.Config.ModName), new Actions.DisplayMessageBoxParams()
+        {
+            StartupLocation = Actions.WindowStartupLocation.CenterScreen,
+            Type = Actions.MessageBoxType.OkCancel
+        });
+
+        if (!deleteConfirm)
+            return;
+        
         var directory = Path.GetDirectoryName(_modTuple!.Path) ?? throw new InvalidOperationException(Resources.ErrorFailedToGetDirectoryOfMod.Get());
         Directory.Delete(directory, true);
     }

--- a/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
@@ -204,4 +204,8 @@ public static class Resources
     // Update 1.26.0: Drag & Drop Mods
     public static IDictionaryResource<string> DragDropInstalledModsTitle { get; set; }
     public static IDictionaryResource<string> DragDropInstalledModsDescription { get; set; }
+
+    // Update 1.28.4: Delete Mod Dialog
+    public static IDictionaryResource<string> DeleteModDialogTitle { get; set; }
+    public static IDictionaryResource<string> DeleteModDialogDescription { get; set; }
 }

--- a/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
+++ b/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
@@ -716,4 +716,8 @@ For more info, refer to the tutorial. Don't forget to set correct Publish target
     <sys:String x:Key="DownloadPackagesPrevious">Previous</sys:String>
     <sys:String x:Key="DownloadPackagesNext">Next</sys:String>
 
+    <!-- Update 1.28.4: Delete Mod Dialog -->
+    <sys:String x:Key="DeleteModDialogTitle">Delete Mod</sys:String>
+    <sys:String x:Key="DeleteModDialogDescription">{0}&#x0a;will be deleted.</sys:String>
+
 </ResourceDictionary>


### PR DESCRIPTION
Resolves https://github.com/Reloaded-Project/Reloaded-II/issues/269
Only adds en-GB strings, translations needed for other langs.
I'm open to different description wording, I couldn't come up with a phrase I liked without changing OK and Cancel to Yes/No.


![image](https://github.com/user-attachments/assets/a48fa89f-078f-4e09-a6aa-2784aa2b3c87)


When using other languages it fallsback to en-GB, example:
![image](https://github.com/user-attachments/assets/e6d29f98-00f7-4b93-a100-c3e10cf07ae1)

