### PR TITLE
Default Color Adjustments and Consistency for Accessibility

### DIFF
--- a/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/SettingsPage.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/BaseSubpages/SettingsPage.xaml
@@ -101,7 +101,7 @@
                                HorizontalAlignment="Center"
                                TextWrapping="Wrap"
                                FontSize="{DynamicResource FontSizeLarge}"
-                               Style="{DynamicResource RIIDefaultTextBlock}"
+                               Style="{DynamicResource TextblockWithColourChange}"
                                Margin="{DynamicResource CommonItemVerticalMargin}"/>
 
                 <!-- Settings -->

--- a/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
+++ b/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
@@ -77,8 +77,8 @@
     </PackageReference>
     <PackageReference Include="Reloaded.Input" Version="2.2.0" />
     <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
-    <PackageReference Include="Reloaded.WPF" Version="3.3.1" />
-    <PackageReference Include="Reloaded.WPF.Theme.Default" Version="3.2.1" />
+    <PackageReference Include="Reloaded.WPF" Version="3.3.2" />
+    <PackageReference Include="Reloaded.WPF.Theme.Default" Version="3.2.3" />
     <PackageReference Include="Sewer56.UI.Controller.Core" Version="1.1.0" />
     <PackageReference Include="Sewer56.UI.Controller.ReloadedInput.Configurator" Version="1.2.3" />
     <PackageReference Include="Sewer56.UI.Controller.WPF" Version="1.1.3" />

--- a/source/Reloaded.Mod.Launcher/Theme/Halogen/Styles.xaml
+++ b/source/Reloaded.Mod.Launcher/Theme/Halogen/Styles.xaml
@@ -466,7 +466,6 @@
 
     <!-- Checkbox -->
     <Style x:Key="DefaultCheckBoxBase" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource BaseStyle}">
-
         <Setter Property="Background" Value="{StaticResource BorderColorBrush}"/>
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Height" Value="{DynamicResource CheckboxSize}" />
@@ -532,9 +531,17 @@
     </Style>
 
     <Style x:Key="DefaultCheckBox" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource DefaultCheckBoxBase}">
-
-        <!-- Colour the checkbox. -->
         <Style.Triggers>
+            <!-- Colour text content on IsMouseOver. -->
+            <Trigger Property="IsMouseOver" Value="True">
+                <Trigger.EnterActions>
+                    <BeginStoryboard Storyboard="{StaticResource ForegroundFadeTextToAccentLightest}"/>
+                </Trigger.EnterActions>
+                <Trigger.ExitActions>
+                    <BeginStoryboard Storyboard="{StaticResource ForegroundFadeAccentLightestToText}"/>
+                </Trigger.ExitActions>
+            </Trigger>
+            <!-- Colour the checkbox. -->
             <Trigger Property="IsChecked" Value="True">
                 <Trigger.EnterActions>
                     <BeginStoryboard Storyboard="{StaticResource BackgroundFadeBorderToAccentLighter}"/>


### PR DESCRIPTION
Resolves https://github.com/Reloaded-Project/Reloaded-II/issues/500

* Increase brightness of the secondary type text 3c3c3c -> 7c7c7c; Effectively a brighter gray
* MouseOver for Checkbox content (text associated) and for the Reloaded Warning added for consistency