### PR TITLE
Enhancement: AddApplication warns for OneDrive and non-ascii paths

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
@@ -208,4 +208,8 @@ public static class Resources
     // Update 1.28.4: Delete Mod Dialog
     public static IDictionaryResource<string> DeleteModDialogTitle { get; set; }
     public static IDictionaryResource<string> DeleteModDialogDescription { get; set; }
+
+    // Update 1.28.6: Problematic Path Warnings
+    public static IDictionaryResource<string> ProblematicPathTitle { get; set; }
+    public static IDictionaryResource<string> ProblematicPathAppDescription { get; set; }
 }

--- a/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
+++ b/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
@@ -719,5 +719,9 @@ For more info, refer to the tutorial. Don't forget to set correct Publish target
     <!-- Update 1.28.4: Delete Mod Dialog -->
     <sys:String x:Key="DeleteModDialogTitle">Delete Mod</sys:String>
     <sys:String x:Key="DeleteModDialogDescription">{0}&#x0a;will be deleted.</sys:String>
+    
+    <!-- Update 1.28.6: Problematic Path Warnings -->
+    <sys:String x:Key="ProblematicPathTitle">Potentially Problematic Path Detected</sys:String>
+    <sys:String x:Key="ProblematicPathAppDescription">The application you selected is in a folder that is managed by OneDrive or contains non-ASCII (special) characters.&#x0a;It is recommended to move the application to a different path, such as "C:\Games\".&#x0a;Using the application in an unsupported path may result in mods not working.&#x0a;&#x0a;Press OK to add the application anyway.</sys:String>
 
 </ResourceDictionary>


### PR DESCRIPTION
Resolves https://github.com/Reloaded-Project/Reloaded-II/issues/503

Language TBD / feel free to change.
EN lang only; Translations needed eventually (presumably in a follow up sync etc)
It may be too wordy/technical.

I considered saying `game` instead of application, but the rest of Reloaded-II refers to added targets as applications.

![image](https://github.com/user-attachments/assets/433bfe1a-902e-4bef-87e8-611e136e1a5a)

