### PR TITLE
Enhancement: Warn on R-II path in OneDrive/non-ascii on startup

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
@@ -212,4 +212,5 @@ public static class Resources
     // Update 1.28.6: Problematic Path Warnings
     public static IDictionaryResource<string> ProblematicPathTitle { get; set; }
     public static IDictionaryResource<string> ProblematicPathAppDescription { get; set; }
+    public static IDictionaryResource<string> ProblematicPathReloadedDescription { get; set; }
 }

--- a/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Static/Resources.cs
@@ -213,4 +213,5 @@ public static class Resources
     public static IDictionaryResource<string> ProblematicPathTitle { get; set; }
     public static IDictionaryResource<string> ProblematicPathAppDescription { get; set; }
     public static IDictionaryResource<string> ProblematicPathReloadedDescription { get; set; }
+    public static IDictionaryResource<string> ProblematicPathModsDescription { get; set; }
 }

--- a/source/Reloaded.Mod.Launcher/App.xaml.cs
+++ b/source/Reloaded.Mod.Launcher/App.xaml.cs
@@ -43,14 +43,31 @@ public partial class App : Application
         var window = new MainWindow();
 
         // Warn if OneDrive or NonAsciiChars detected in Reloaded-II directory
-        bool hasNonAsciiChars = AppContext.BaseDirectory.Any(c => c > 127);
-        if (AppContext.BaseDirectory.Contains("OneDrive") || hasNonAsciiChars)
+        bool reloadedPathHasNonAsciiChars = AppContext.BaseDirectory.Any(c => c > 127);
+        if (AppContext.BaseDirectory.Contains("OneDrive") || reloadedPathHasNonAsciiChars)
         {
             Actions.DisplayMessagebox.Invoke(Lib.Static.Resources.ProblematicPathTitle.Get(), Lib.Static.Resources.ProblematicPathReloadedDescription.Get(), new Actions.DisplayMessageBoxParams()
+            {
+                StartupLocation = Actions.WindowStartupLocation.CenterScreen,
+                Type = Actions.MessageBoxType.Ok
+            });
+        }
+        else // We only do this check if the Reloaded-II directory check passed
+        {
+            // Warn if OneDrive or NonAsciiChars detected in Mods directory
+            var modsDirectory = Lib.IoC.Get<LoaderConfig>().GetModConfigDirectory();
+            if (modsDirectory != null)
+            {
+                bool modsDirectoryPathHasNonAsciiChars = modsDirectory.Any(c => c > 127);
+                if (modsDirectory.Contains("OneDrive") || modsDirectoryPathHasNonAsciiChars)
                 {
-                    StartupLocation = Actions.WindowStartupLocation.CenterScreen,
-                    Type = Actions.MessageBoxType.Ok
-                });
+                    Actions.DisplayMessagebox.Invoke(Lib.Static.Resources.ProblematicPathTitle.Get(), Lib.Static.Resources.ProblematicPathModsDescription.Get(), new Actions.DisplayMessageBoxParams()
+                    {
+                        StartupLocation = Actions.WindowStartupLocation.CenterScreen,
+                        Type = Actions.MessageBoxType.Ok
+                    });
+                }
+            }
         }
 
         window.ShowDialog();

--- a/source/Reloaded.Mod.Launcher/App.xaml.cs
+++ b/source/Reloaded.Mod.Launcher/App.xaml.cs
@@ -39,13 +39,26 @@ public partial class App : Application
         StartProfileOptimization();
         PrepareWebRequests();
 
+        // Need to construct MainWindow before invoking any dialog, otherwise Shutdown will be called on closing the dialog
         var window = new MainWindow();
+
+        // Warn if OneDrive or NonAsciiChars detected in Reloaded-II directory
+        bool hasNonAsciiChars = AppContext.BaseDirectory.Any(c => c > 127);
+        if (AppContext.BaseDirectory.Contains("OneDrive") || hasNonAsciiChars)
+        {
+            Actions.DisplayMessagebox.Invoke(Lib.Static.Resources.ProblematicPathTitle.Get(), Lib.Static.Resources.ProblematicPathReloadedDescription.Get(), new Actions.DisplayMessageBoxParams()
+                {
+                    StartupLocation = Actions.WindowStartupLocation.CenterScreen,
+                    Type = Actions.MessageBoxType.Ok
+                });
+        }
+
         window.ShowDialog();
     }
 
     private void SetupResources()
     {
-        var launcherFolder= AppContext.BaseDirectory;
+        var launcherFolder = AppContext.BaseDirectory;
         var languageSelector = new XamlFileSelector($"{launcherFolder}\\Assets\\Languages");
         var themeSelector    = new XamlFileSelector($"{launcherFolder}\\Theme");
         

--- a/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
+++ b/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
@@ -724,5 +724,6 @@ For more info, refer to the tutorial. Don't forget to set correct Publish target
     <sys:String x:Key="ProblematicPathTitle">Potentially Problematic Path Detected</sys:String>
     <sys:String x:Key="ProblematicPathAppDescription">The application you selected is in a folder that is managed by OneDrive or contains non-ASCII (special) characters.&#x0a;It is recommended to move the application to a different path, such as "C:\Games\".&#x0a;Using the application in an unsupported path may result in mods not working.&#x0a;&#x0a;Press OK to add the application anyway.</sys:String>
     <sys:String x:Key="ProblematicPathReloadedDescription">Reloaded-II has detected it is installed in a folder that is managed by OneDrive or contains non-ASCII (special) characters.&#x0a;It is recommended to move your Reloaded-II folder to a different path, such as "C:\Reloaded-II\".&#x0a;Keeping Reloaded-II in an unsupported path may result in mods not working.</sys:String>
+    <sys:String x:Key="ProblematicPathModsDescription">Reloaded-II has detected your mods folder is managed by OneDrive or contains non-ASCII (special) characters.&#x0a;It is recommended to move your mods folder to a different path.&#x0a;Keeping mods in an unsupported path may result in problems running mods.</sys:String>
 
 </ResourceDictionary>

--- a/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
+++ b/source/Reloaded.Mod.Launcher/Assets/Languages/en-GB.xaml
@@ -723,5 +723,6 @@ For more info, refer to the tutorial. Don't forget to set correct Publish target
     <!-- Update 1.28.6: Problematic Path Warnings -->
     <sys:String x:Key="ProblematicPathTitle">Potentially Problematic Path Detected</sys:String>
     <sys:String x:Key="ProblematicPathAppDescription">The application you selected is in a folder that is managed by OneDrive or contains non-ASCII (special) characters.&#x0a;It is recommended to move the application to a different path, such as "C:\Games\".&#x0a;Using the application in an unsupported path may result in mods not working.&#x0a;&#x0a;Press OK to add the application anyway.</sys:String>
+    <sys:String x:Key="ProblematicPathReloadedDescription">Reloaded-II has detected it is installed in a folder that is managed by OneDrive or contains non-ASCII (special) characters.&#x0a;It is recommended to move your Reloaded-II folder to a different path, such as "C:\Reloaded-II\".&#x0a;Keeping Reloaded-II in an unsupported path may result in mods not working.</sys:String>
 
 </ResourceDictionary>


### PR DESCRIPTION
Resolves https://github.com/Reloaded-Project/Reloaded-II/issues/502

On boot, this appears if OneDrive or non-ascii chars are detected in the path Reloaded-II is contained in:

<img width="639" alt="image" src="https://github.com/user-attachments/assets/9b4ba6e7-5627-4af9-93ce-36dfeda56882" />

Clicking OK dismisses and the program continues as usual.

This will appear *every time* if detected.
I debated about introducing "ignore permanently", but ultimately the goal of this is to inform users and reduce possible issue reports relating to path issues, so I think its wise to permanently nag the user if these scenarios are detected.

--
For the first time user, this would appear and then the R-II Tutorial would appear at the same time if the detection occurs. They must complete or skip the tutorial before they can interact with the warning. After both are dismissed the main window loads.

I don't consider this case very likely, as first time users would hopefully have been automatically moved to a safe directory per https://github.com/Reloaded-Project/Reloaded-II/pull/504. And while its less than ideal visually, nothing is broken in this first-time state.
