### PR TITLE
Add support for ordering items in mod configs.

### DIFF
--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -4,6 +4,7 @@ using Color = System.Windows.Media.Color;
 using PropertyItem = HandyControl.Controls.PropertyItem;
 using TextBox = System.Windows.Controls.TextBox;
 using OpenFileDialog = System.Windows.Forms.OpenFileDialog;
+using System.ComponentModel.DataAnnotations;
 
 namespace Reloaded.Mod.Launcher.Controls;
 
@@ -19,12 +20,19 @@ public class PropertyGridEx : PropertyGrid
 
     private List<PropertyItem> _properties = new List<PropertyItem>();
     private List<PropertyDescriptor> _propertyDescriptors = new List<PropertyDescriptor>();
+    private int _currMaxPriority = int.MaxValue;
 
     protected override PropertyItem CreatePropertyItem(PropertyDescriptor propertyDescriptor, object component, string category,
         int hierarchyLevel)
     {
         ((PropertyResolverEx)PropertyResolver).Descriptor = propertyDescriptor;
         var item = base.CreatePropertyItem(propertyDescriptor, component, category, hierarchyLevel);
+
+        /// Uses <see cref="DisplayAttribute.Order"/> for item ordering.
+        /// Unordered items are given a decreasing maximum value to maintain the existing "order" in configs.
+        /// It does means that unordered items will always be at the top, but oh well.
+        item.Priority = propertyDescriptor.Attributes.OfType<DisplayAttribute>().FirstOrDefault()?.Order ?? _currMaxPriority--;
+
         _properties.Add(item);
         _propertyDescriptors.Add(propertyDescriptor);
         return item;

--- a/source/Reloaded.Mod.Launcher/Pages/Dialogs/ConfigureModDialog.xaml
+++ b/source/Reloaded.Mod.Launcher/Pages/Dialogs/ConfigureModDialog.xaml
@@ -39,6 +39,7 @@
                                  Margin="{DynamicResource CommonItemVerticalMargin}"
                                  Style="{StaticResource PropertyGridBaseStyle}" 
                                  DefaultSorting="Hierarchy"
+                                 SortByPriority="True"
                                  x:Name="PropertyGridEx" />
 
         <Grid Grid.Row="2">

--- a/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
+++ b/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.6.5</PackageVersion>
+    <PackageVersion>1.6.6</PackageVersion>
     <PackageId>Reloaded.Mod.Templates</PackageId>
     <Title>Reloaded-II Mod Templates</Title>
     <Authors>Sewer56</Authors>

--- a/source/Reloaded.Mod.Template/templates/configurable/Config.cs
+++ b/source/Reloaded.Mod.Template/templates/configurable/Config.cs
@@ -102,6 +102,15 @@ public class Config : Configurable<Config>
         multiSelect: true,
         forceFileSystem: true)]
     public string Folder { get; set; } = "";
+
+    [Display(Order = 3)]
+    public int OrderFirst { get; set; }
+
+    [Display(Order = 2)]
+    public int OrderSecond { get; set; }
+
+    [Display(Order = 1)]
+    public int OrderThird { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
Uses the `DisplayAttribute`'s `Order` to set the `PropertyItem`'s existing `Priority` property, with a bit of a code to stop every mod's config order from shuffling.

Also added examples to the template.