### PR TITLE
Add support for named enum values in configs.

### DIFF
--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -21,7 +21,6 @@ public class PropertyGridEx : PropertyGrid
 
     private List<PropertyItem> _properties = new List<PropertyItem>();
     private List<PropertyDescriptor> _propertyDescriptors = new List<PropertyDescriptor>();
-    private int _currMaxPriority = int.MaxValue;
 
     protected override PropertyItem CreatePropertyItem(PropertyDescriptor propertyDescriptor, object component, string category,
         int hierarchyLevel)
@@ -30,9 +29,7 @@ public class PropertyGridEx : PropertyGrid
         var item = base.CreatePropertyItem(propertyDescriptor, component, category, hierarchyLevel);
 
         /// Uses <see cref="DisplayAttribute.Order"/> for item ordering.
-        /// Unordered items are given a decreasing maximum value to maintain the existing "order" in configs.
-        /// It does means that unordered items will always be at the top, but oh well.
-        item.Priority = propertyDescriptor.Attributes.OfType<DisplayAttribute>().FirstOrDefault()?.Order ?? _currMaxPriority--;
+        item.Priority = propertyDescriptor.Attributes.OfType<DisplayAttribute>().FirstOrDefault()?.Order ?? item.Priority;
 
         _properties.Add(item);
         _propertyDescriptors.Add(propertyDescriptor);

--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -5,6 +5,7 @@ using PropertyItem = HandyControl.Controls.PropertyItem;
 using TextBox = System.Windows.Controls.TextBox;
 using OpenFileDialog = System.Windows.Forms.OpenFileDialog;
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 
 namespace Reloaded.Mod.Launcher.Controls;
 
@@ -348,11 +349,30 @@ public class EnumPropertyEditor : PropertyEditorBase
         return new System.Windows.Controls.ComboBox
         {
             IsEnabled = !propertyItem.IsReadOnly,
-            ItemsSource = Enum.GetValues(propertyItem.PropertyType)
+            ItemsSource = GetItems(propertyItem.PropertyType),
+            DisplayMemberPath = "Name",
+            SelectedValuePath = "Value",
         };
     }
 
+    private static List<ItemTuple> GetItems(Type type)
+    {
+        var items = new List<ItemTuple>();
+        var values = Enum.GetValues(type);
+        foreach (var value in values)
+        {
+            var name = value.ToString()!;
+            name = type.GetMember(name).First().GetCustomAttribute<DisplayAttribute>()?.Name ?? name;
+
+            items.Add(new(name, value));
+        }
+
+        return items;
+    }
+
     public override DependencyProperty GetDependencyProperty() => Selector.SelectedValueProperty;
+
+    private record ItemTuple(string Name, object Value);
 }
 
 public class NumberPropertyEditor : PropertyEditorBase

--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -28,7 +28,7 @@ public class PropertyGridEx : PropertyGrid
         ((PropertyResolverEx)PropertyResolver).Descriptor = propertyDescriptor;
         var item = base.CreatePropertyItem(propertyDescriptor, component, category, hierarchyLevel);
 
-        /// Uses <see cref="DisplayAttribute.Order"/> for item ordering.
+        // Uses 'DisplayAttribute.Order' for item ordering.
         item.Priority = propertyDescriptor.Attributes.OfType<DisplayAttribute>().FirstOrDefault()?.Order ?? item.Priority;
 
         _properties.Add(item);
@@ -354,16 +354,17 @@ public class EnumPropertyEditor : PropertyEditorBase
 
     private static ItemTuple[] GetItems(Type type)
     {
-        var items = new List<ItemTuple>();
-        foreach (var value in Enum.GetValues(type))
+        var values = Enum.GetValues(type);
+        var items = GC.AllocateUninitializedArray<ItemTuple>(values.Length);
+        for (int x = 0; x < values.Length; x++)
         {
+            var value = values.GetValue(x)!;
             var name = value.ToString()!;
             name = type.GetMember(name).First().GetCustomAttribute<DisplayAttribute>()?.Name ?? name;
-
-            items.Add(new(name, value));
+            items[x] = new(name, value);
         }
 
-        return items.ToArray();
+        return items;
     }
 
     public override DependencyProperty GetDependencyProperty() => Selector.SelectedValueProperty;

--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -352,11 +352,10 @@ public class EnumPropertyEditor : PropertyEditorBase
         };
     }
 
-    private static List<ItemTuple> GetItems(Type type)
+    private static ItemTuple[] GetItems(Type type)
     {
         var items = new List<ItemTuple>();
-        var values = Enum.GetValues(type);
-        foreach (var value in values)
+        foreach (var value in Enum.GetValues(type))
         {
             var name = value.ToString()!;
             name = type.GetMember(name).First().GetCustomAttribute<DisplayAttribute>()?.Name ?? name;
@@ -364,12 +363,12 @@ public class EnumPropertyEditor : PropertyEditorBase
             items.Add(new(name, value));
         }
 
-        return items;
+        return items.ToArray();
     }
 
     public override DependencyProperty GetDependencyProperty() => Selector.SelectedValueProperty;
 
-    private record ItemTuple(string Name, object Value);
+    private record struct ItemTuple(string Name, object Value);
 }
 
 public class NumberPropertyEditor : PropertyEditorBase

--- a/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
+++ b/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.6.6</PackageVersion>
+    <PackageVersion>1.6.7</PackageVersion>
     <PackageId>Reloaded.Mod.Templates</PackageId>
     <Title>Reloaded-II Mod Templates</Title>
     <Authors>Sewer56</Authors>

--- a/source/Reloaded.Mod.Template/templates/configurable/Config.cs
+++ b/source/Reloaded.Mod.Template/templates/configurable/Config.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Reloaded.Mod.Template.Template.Configuration;
 using Reloaded.Mod.Interfaces.Structs;
+using System.ComponentModel.DataAnnotations;
 
 namespace Reloaded.Mod.Template.Configuration;
 
@@ -59,7 +60,9 @@ public class Config : Configurable<Config>
         IsMediocre,
         IsOk,
         IsCool,
-        ILoveIt
+
+        [Display(Name = "I Love It!!!")]
+        ILoveIt,
     }
     
     [DisplayName("Int Slider")]


### PR DESCRIPTION
Adds support for named enum values in configs using `Display`'s `Name` property. Apparently, the `DisplayName` attribute doesn't support enum values, sadge.

Also, simplified the item ordering to use either the specified order or its default (`0`). I expected shuffling based on previous tests but those weren't using the built-in Priority.