### PR TITLE
Fix crashes when resetting configs.

### DIFF
--- a/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
+++ b/source/Reloaded.Mod.Launcher/Controls/PropertyGridEx.cs
@@ -62,7 +62,7 @@ public class PropertyGridEx : PropertyGrid
         {
             var property = _properties[x];
             if (property.DefaultValue != null)
-                _propertyDescriptors[x].SetValue(property.Value, property.DefaultValue);
+                _propertyDescriptors[x].SetValue(property.Value, Convert.ChangeType(property.DefaultValue, property.PropertyType));
         }
     }
 }


### PR DESCRIPTION
The `DefaultValue` property stores integers as ints, which caused a crash if the target property was different integer type (byte, short, etc). Now runs `Convert.ChangeType` on the default value before setting it.