### PR TITLE
Fix: Mod template ConfigContext not being set.

### DIFF
--- a/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
+++ b/source/Reloaded.Mod.Template/Reloaded.Mod.Template.NuGet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.6.7</PackageVersion>
+    <PackageVersion>1.6.8</PackageVersion>
     <PackageId>Reloaded.Mod.Templates</PackageId>
     <Title>Reloaded-II Mod Templates</Title>
     <Authors>Sewer56</Authors>

--- a/source/Reloaded.Mod.Template/templates/configurable/Template/Startup.cs
+++ b/source/Reloaded.Mod.Template/templates/configurable/Template/Startup.cs
@@ -64,6 +64,8 @@ public class Startup : IMod
         // Need a different name, format or more configurations? Modify the `Configurator`.
         // If you do not want a config, remove Configuration folder and Config class.
         var configurator = new Configurator(_modLoader.GetModConfigDirectory(_modConfig.ModId));
+        configurator.SetContext(new() { Application = _modLoader.GetAppConfig() } );
+
         _configuration = configurator.GetConfiguration<Config>(0);
         _configuration.ConfigurationUpdated += OnConfigurationUpdated;
 #endif


### PR DESCRIPTION
The template doesn't set any `ConfigContext` when initialized through the loader. This sets the context with at least the `IApplicationConfig`. Not sure if the other properties are possible to fill, or even useful to.

For reference, I needed it for app specific configs.