### PR TITLE
.NET 10 - Blocked by Linux Support

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -77,7 +77,12 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
-    
+
+    - name: Setup Dotnet SDK (10.0)
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+
     - name: Get Dotnet Info
       run: dotnet --info
 

--- a/.github/workflows/reloaded-utils-server.yml
+++ b/.github/workflows/reloaded-utils-server.yml
@@ -56,10 +56,10 @@ jobs:
       with:
         dotnet-version: 5.0.x
         
-    - name: Setup .NET Core SDK (9.0)
+    - name: Setup Dotnet SDK (10.0)
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: '10.0.x'
         
     - name: Setup Node.js
       uses: actions/setup-node@v6

--- a/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
+++ b/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>12.0</LangVersion>
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.11" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Publish.ps1
+++ b/source/Publish.ps1
@@ -81,7 +81,7 @@ dotnet publish "$communityProjectPath" -c Release -r win-x64 --self-contained fa
 dotnet publish "$installerProjectPath" -f net472 -o "$installerPublishDirectory"
 
 # Build Installer (Static/Linux)
-dotnet publish "$installerCliProjectPath" -f net9.0-windows -r win-x64 -o "$installerStaticPublishDirectory"
+dotnet publish "$installerCliProjectPath" -f net10.0-windows -r win-x64 -o "$installerStaticPublishDirectory"
 
 # Build Templates
 dotnet pack "$templateProjectPath" -o "$templatePublishDirectory"

--- a/source/Reloaded.Mod.Installer.Cli/Reloaded.Mod.Installer.Cli.csproj
+++ b/source/Reloaded.Mod.Installer.Cli/Reloaded.Mod.Installer.Cli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>NET472;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks>NET472;net10.0-windows</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AssemblyName>Setup-Linux</AssemblyName>
@@ -11,7 +11,7 @@
         <DebugType>portable</DebugType>
     </PropertyGroup>
 
-    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0-windows'))">
+    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0-windows'))">
         <PublishAot>true</PublishAot>
     </PropertyGroup>
 

--- a/source/Reloaded.Mod.Installer.Lib/Reloaded.Mod.Installer.Lib.csproj
+++ b/source/Reloaded.Mod.Installer.Lib/Reloaded.Mod.Installer.Lib.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>NET472;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks>NET472;net10.0-windows</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0-windows'))">
+    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0-windows'))">
         <PublishAot>true</PublishAot>
     </PropertyGroup>
 

--- a/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
+++ b/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>NET472;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>NET472;net10.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>preview</LangVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -15,7 +15,7 @@
     <_SuppressWpfTrimError>true</_SuppressWpfTrimError>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0-windows'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0-windows'))">
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 

--- a/source/Reloaded.Mod.Launcher.Lib/Reloaded.Mod.Launcher.Lib.csproj
+++ b/source/Reloaded.Mod.Launcher.Lib/Reloaded.Mod.Launcher.Lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <LangVersion>preview</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS0067</NoWarn>
@@ -15,7 +15,7 @@
     <PackageReference Include="dll_syringe.Net.Sys" Version="0.16.0" />
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="IoC.Container" Version="1.3.8" />
-    <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0-beta.0" />
+    <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="PhotoSauce.NativeCodecs.Libjxl" Version="0.6.1-ci222723" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">

--- a/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
+++ b/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
 	  <LangVersion>preview</LangVersion>
 	  <UseWPF>true</UseWPF>
     <AssemblyName>Reloaded-II</AssemblyName>

--- a/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
+++ b/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <NoWarn>1701;1702;CS1591;NU5104;CS0067</NoWarn>
     <Nullable>enable</Nullable>
@@ -29,7 +29,7 @@
     <PackageReference Include="Equals.Fody" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.11" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Reloaded.Mod.Loader.Tests/Reloaded.Mod.Loader.Tests.csproj
+++ b/source/Reloaded.Mod.Loader.Tests/Reloaded.Mod.Loader.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>

--- a/source/Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj
+++ b/source/Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
-    <RuntimeFrameworkVersion>9.0.8</RuntimeFrameworkVersion>
-    <RollForward>Minor</RollForward> <!-- Allow 9.X greater than 9.0.8 -->
-    
-	  <LangVersion>preview</LangVersion>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RollForward>Minor</RollForward>
+	<LangVersion>preview</LangVersion>
     <AssemblyTitle>Reloaded.Mod.Loader</AssemblyTitle>
-	  <UseWindowsForms>true</UseWindowsForms>
+	<UseWindowsForms>true</UseWindowsForms>
     <Product>Reloaded.Mod.Loader</Product>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -98,7 +96,7 @@
     <PackageReference Include="Colorful.Console" Version="1.2.2-reloaded" />
     <PackageReference Include="Indieteur.SteamAppsManAndVDFAPI" Version="1.0.5" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.11" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" ExcludeAssets="runtime" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* Minimal upgrade to test out .NET 10
~~* Upgrade CI to latest actions, bump node 14 to node 20 to match other R-II mod repo~~ | Moved to other PR
* Does not update the Template

--

Windows tested ✔️ 
Linux - ❌ - unable to add new games - breaks on attempting to invoke the FileDialog
<img width="989" height="307" alt="image" src="https://github.com/user-attachments/assets/ceacc31f-17ef-45e8-ba8d-3e3b08aa023e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all components to target .NET 10.0, upgrading from .NET 9.0.
  * Updated build infrastructure and GitHub Actions workflows to support the new framework version.
  * Updated build tools and dependencies to compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->