### PR TITLE
Updated: Dependencies (Nov 2025)

### DIFF
--- a/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
+++ b/source/Mods/Reloaded.Utils.Server/Reloaded.Utils.Server.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Installer.Cli/Reloaded.Mod.Installer.Cli.csproj
+++ b/source/Reloaded.Mod.Installer.Cli/Reloaded.Mod.Installer.Cli.csproj
@@ -20,9 +20,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
         <PackageReference Include="ConsoleProgressBar" Version="2.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+        <PackageReference Include="System.Text.Json" Version="10.0.0" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 

--- a/source/Reloaded.Mod.Installer.DependencyInstaller/Reloaded.Mod.Installer.DependencyInstaller.csproj
+++ b/source/Reloaded.Mod.Installer.DependencyInstaller/Reloaded.Mod.Installer.DependencyInstaller.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="NetCoreInstallChecker" Version="3.0.4" />
     <PackageReference Include="RedistributableChecker" Version="0.2.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Reloaded.Mod.Installer.Lib/Reloaded.Mod.Installer.Lib.csproj
+++ b/source/Reloaded.Mod.Installer.Lib/Reloaded.Mod.Installer.Lib.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.183">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -31,6 +31,10 @@
         <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="System.Memory" Version="4.6.3" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+        <PackageReference Include="System.Text.Json" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
+++ b/source/Reloaded.Mod.Installer/Reloaded.Mod.Installer.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="ConsoleProgressBar" Version="2.0.0" />
     <PackageReference Include="Costura.Fody" Condition="'$(TargetFramework)' == 'net472'" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
@@ -47,7 +47,9 @@
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/source/Reloaded.Mod.Launcher.Lib/Reloaded.Mod.Launcher.Lib.csproj
+++ b/source/Reloaded.Mod.Launcher.Lib/Reloaded.Mod.Launcher.Lib.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="dll_syringe.Net.Sys" Version="0.16.0" />
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="IoC.Container" Version="1.3.8" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0-beta.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
@@ -21,7 +21,7 @@
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="System.Management" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
+++ b/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
@@ -65,10 +65,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
     <PackageReference Include="HandyControl" Version="3.2.0-reloaded-1.1.0" />
-    <PackageReference Include="HandyControl.Lang.en" Version="3.3.0" />
+    <PackageReference Include="HandyControl.Lang.en" Version="3.5.1" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />
     <PackageReference Include="Ninject" Version="3.3.6" />
@@ -76,7 +76,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Reloaded.Input" Version="2.2.0" />
-    <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
+    <PackageReference Include="Reloaded.Memory" Version="9.4.3" />
     <PackageReference Include="Reloaded.WPF" Version="3.3.2" />
     <PackageReference Include="Reloaded.WPF.Theme.Default" Version="3.2.3" />
     <PackageReference Include="Sewer56.UI.Controller.Core" Version="1.1.0" />

--- a/source/Reloaded.Mod.Loader.Community/Reloaded.Mod.Loader.Community.csproj
+++ b/source/Reloaded.Mod.Loader.Community/Reloaded.Mod.Loader.Community.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="Standart.Hash.xxHash" Version="3.1.0" />
   </ItemGroup>
 

--- a/source/Reloaded.Mod.Loader.IO/Reloaded.Mod.Loader.IO.csproj
+++ b/source/Reloaded.Mod.Loader.IO/Reloaded.Mod.Loader.IO.csproj
@@ -22,15 +22,15 @@
   </PropertyGroup>
 	
   <ItemGroup>
-	<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+	<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="Equals.Fody" Version="4.0.2">
 	  <PrivateAssets>all</PrivateAssets>
 	</PackageReference>
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Reloaded.Memory" Version="9.4.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
+++ b/source/Reloaded.Mod.Loader.Server/Reloaded.Mod.Loader.Server.csproj
@@ -22,21 +22,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
-    <PackageReference Include="AnyOf" Version="0.5.0" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
+    <PackageReference Include="AnyOf" Version="0.5.0.1" />
     <PackageReference Include="LiteNetLib" Version="1.3.1" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Equals.Fody" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.11" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Reloaded.Messaging" Version="2.0.1" />
+    <PackageReference Include="Reloaded.Messaging" Version="2.0.2" />
     <PackageReference Include="Reloaded.Messaging.Extras.Runtime" Version="2.0.0" />
-    <PackageReference Include="Reloaded.Messaging.Host.LiteNetLib" Version="2.0.0" />
-    <PackageReference Include="Reloaded.Messaging.Serializer.MessagePack" Version="2.0.0" />
+    <PackageReference Include="Reloaded.Messaging.Host.LiteNetLib" Version="2.0.2" />
+    <PackageReference Include="Reloaded.Messaging.Serializer.MessagePack" Version="2.0.1" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/source/Reloaded.Mod.Loader.Tests/Reloaded.Mod.Loader.Tests.csproj
+++ b/source/Reloaded.Mod.Loader.Tests/Reloaded.Mod.Loader.Tests.csproj
@@ -45,10 +45,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Reloaded.Mod.Loader.Update.Packaging/Reloaded.Mod.Loader.Update.Packaging.csproj
+++ b/source/Reloaded.Mod.Loader.Update.Packaging/Reloaded.Mod.Loader.Update.Packaging.csproj
@@ -25,12 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="Sewer56.Update" Version="4.0.2" />
     <PackageReference Include="Sewer56.Update.Extractors.SevenZipSharp" Version="1.1.4" GeneratePathProperty="true" />
     <PackageReference Include="Sewer56.Update.Packaging" Version="3.0.1" />
     <PackageReference Include="Sewer56.Update.Resolvers.NuGet" Version="1.4.1" />
     <PackageReference Include="Sewer56.Update.Resolvers.GameBanana" Version="1.4.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Reloaded.Mod.Loader.Update/Reloaded.Mod.Loader.Update.csproj
+++ b/source/Reloaded.Mod.Loader.Update/Reloaded.Mod.Loader.Update.csproj
@@ -25,14 +25,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="DeepCloner" Version="0.10.4" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="NetCoreInstallChecker" Version="3.0.4" />
     <PackageReference Include="NuGet.Packaging" Version="6.11.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.7.1" />
-    <PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="Polly" Version="8.6.4" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -40,11 +40,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="RedistributableChecker" Version="0.2.3" />
-    <PackageReference Include="ReverseMarkdown" Version="4.6.0" />
+    <PackageReference Include="ReverseMarkdown" Version="4.7.1" />
     <PackageReference Include="Sewer56.Update" Version="4.0.2" />
     <PackageReference Include="Sewer56.Update.Misc" Version="1.1.0" />
     <PackageReference Include="Sewer56.Update.Resolvers.GitHub" Version="1.5.2" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/source/Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj
+++ b/source/Reloaded.Mod.Loader/Reloaded.Mod.Loader.csproj
@@ -93,11 +93,11 @@
     <ProjectReference Include="..\Reloaded.Mod.Loader.IO\Reloaded.Mod.Loader.IO.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
     <PackageReference Include="Colorful.Console" Version="1.2.2-reloaded" />
     <PackageReference Include="Indieteur.SteamAppsManAndVDFAPI" Version="1.0.5" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.11" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" ExcludeAssets="runtime" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Tools/Reloaded.Publisher/Reloaded.Publisher.csproj
+++ b/source/Tools/Reloaded.Publisher/Reloaded.Publisher.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation" Version="11.12.0" />
     <PackageReference Include="ShellProgressBar" Version="5.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
* Dependencies sweep as usual. Was planning to do this after NET 10 upgrade, but with Linux support being broken this should go in first.
* Explicitly install safe versions of currently vulnerable transitive dependencies
* ILLink to final NET 9 version since NET 10 is blocked atm.
* ~~Unblock forcing NET 9.0.4; 9.0.11 is fine to use.~~ Crashes on game launch

Note: a few libraries dropped NET 5 / NET 6, but still included NET Standard 2.0. My understanding is so long as NET Standard 2.0 support exists this is safe, but let me know if not.