### PR TITLE
CI: Update actions and node 14->20

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -45,9 +45,9 @@ jobs:
     
     # Required for C#10 features.
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '14'
+        node-version: '20'
     
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -59,22 +59,22 @@ jobs:
       run: npm install -g auto-changelog
    
     - name: Setup Dotnet SDK (5.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '5.0.x'
 
     - name: Setup Dotnet SDK (7.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '7.0.x'
 
     - name: Setup Dotnet SDK (8.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '8.0.x'
 
     - name: Setup Dotnet SDK (9.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     
@@ -121,7 +121,7 @@ jobs:
         }
         
     - name: Upload Chocolatey Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Chocolatey Package
@@ -130,7 +130,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Reloaded Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Loader Build
@@ -139,7 +139,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Installer Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Installer
@@ -150,7 +150,7 @@ jobs:
         retention-days: 0
          
     - name: Upload NuGet Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: NuGet Packages
@@ -159,7 +159,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Changelog
@@ -168,7 +168,7 @@ jobs:
         retention-days: 0
     
     - name: Upload Tools Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Tools

--- a/.github/workflows/reloaded-utils-server.yml
+++ b/.github/workflows/reloaded-utils-server.yml
@@ -46,25 +46,25 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: 'recursive'
         
     - name: Setup .NET Core SDK (5.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 5.0.x
         
     - name: Setup .NET Core SDK (9.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 9.0.x
         
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '14'
+        node-version: '20'
         
     - name: Setup AutoChangelog
       run: npm install -g auto-changelog
@@ -83,7 +83,7 @@ jobs:
       run: ./source/Mods/Reloaded.Utils.Server/Publish.ps1 -ChangelogPath "$env:PUBLISH_CHANGELOG_PATH" -BuildR2R true
       
     - name: Upload GitHub Release Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: GitHub Release
@@ -92,7 +92,7 @@ jobs:
           ${{ env.PUBLISH_GITHUB_PATH }}/*
           
     - name: Upload GameBanana Release Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: GameBanana Release
@@ -101,7 +101,7 @@ jobs:
           ${{ env.PUBLISH_GAMEBANANA_PATH }}/*
         
     - name: Upload NuGet Release Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: NuGet Release
@@ -110,7 +110,7 @@ jobs:
           ${{ env.PUBLISH_NUGET_PATH }}/*
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Changelog

--- a/source/Reloaded.Mod.Template/templates/configurable/.github/workflows/reloaded.yml
+++ b/source/Reloaded.Mod.Template/templates/configurable/.github/workflows/reloaded.yml
@@ -48,25 +48,25 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: 'recursive'
         
     - name: Setup .NET Core SDK (5.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 5.0.x
         
     - name: Setup .NET Core SDK (9.0)
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 9.0.x
         
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '14'
+        node-version: '20'
         
     - name: Setup AutoChangelog
       run: npm install -g auto-changelog
@@ -85,7 +85,7 @@ jobs:
       run: ./Publish.ps1 -ChangelogPath "$env:PUBLISH_CHANGELOG_PATH"
       
     - name: Upload GitHub Release Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: GitHub Release
@@ -94,7 +94,7 @@ jobs:
           ${{ env.PUBLISH_GITHUB_PATH }}/*
           
     - name: Upload GameBanana Release Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: GameBanana Release
@@ -103,7 +103,7 @@ jobs:
           ${{ env.PUBLISH_GAMEBANANA_PATH }}/*
         
     - name: Upload NuGet Release Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: NuGet Release
@@ -112,7 +112,7 @@ jobs:
           ${{ env.PUBLISH_NUGET_PATH }}/*
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         # Artifact name
         name: Changelog


### PR DESCRIPTION
May as well have this go in separate from the NET 10 changes since we have to wait for Proton 11 at least.