### PR TITLE
Retroactively fix mods excluding the ModConfig.json when publishing.

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/PublishModDialogViewModel.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/PublishModDialogViewModel.cs
@@ -109,6 +109,8 @@ public class PublishModDialogViewModel : ObservableObject
         IncludeRegexes = new ObservableCollection<StringWrapper>(
             _modTuple.Config.IncludeRegexes.Select(x => new StringWrapper { Value = x })
         );
+        
+        if (!IncludeRegexes.Contains(@"ModConfig\.json")) IncludeRegexes.Add(@"ModConfig\.json");
     }
 
     /// <summary>

--- a/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
+++ b/source/Reloaded.Mod.Launcher/Reloaded.Mod.Launcher.csproj
@@ -7,7 +7,7 @@
 	  <UseWPF>true</UseWPF>
     <AssemblyName>Reloaded-II</AssemblyName>
     <RootNamespace>Reloaded.Mod.Launcher</RootNamespace>
-    <Version>1.29.5</Version>
+    <Version>1.29.6</Version>
     <Copyright>Sewer56 ~ $([System.DateTime]::UtcNow.ToString("s")) | $(Version)</Copyright>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ApplicationIcon>appicon.ico</ApplicationIcon>


### PR DESCRIPTION
Publisher will add the `ModConfig.json` to the `IncludeRegex` if it's missing. Bumps version to 1.29.6.