### PR TITLE
publish: fix ModConfig.json regex inclusion duplicate check

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/PublishModDialogViewModel.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/PublishModDialogViewModel.cs
@@ -110,7 +110,8 @@ public class PublishModDialogViewModel : ObservableObject
             _modTuple.Config.IncludeRegexes.Select(x => new StringWrapper { Value = x })
         );
         
-        if (!IncludeRegexes.Contains(@"ModConfig\.json")) IncludeRegexes.Add(@"ModConfig\.json");
+        if (!IncludeRegexes.Any(e => e.Value.Equals(@"ModConfig\.json", StringComparison.OrdinalIgnoreCase)))
+            IncludeRegexes.Add(@"ModConfig\.json");
     }
 
     /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the mod publishing dialog where ModConfig.json could be added multiple times to the included files list. The dialog now properly detects existing entries using case-insensitive comparison, preventing duplicate configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->