### PR TITLE
Write SteamAppId file only on valid ID retrieval

### DIFF
--- a/source/Reloaded.Mod.Loader/Utilities/Steam/SteamHook.cs
+++ b/source/Reloaded.Mod.Loader/Utilities/Steam/SteamHook.cs
@@ -106,8 +106,12 @@ public class SteamHook
                 break; // We found a valid app ID, so exit the loop.
             }
         }
-        // Write the Steam AppID to a local file and proceed with the original function call.
-        SteamAppId.WriteToDirectory(_applicationFolder, (int)appid);
+
+        // Write the Steam AppID to a local file when correct ID is obtained, and proceed with the original function call.
+        if (appid != 0)
+        {
+            SteamAppId.WriteToDirectory(_applicationFolder, (int)appid);
+        }
         _restartAppIfNecessaryHook.OriginalFunction(appid);
         return false;
     }


### PR DESCRIPTION
## Background
On my PC, Reloaded-II may not run game correctly with mods, with error in log prompting: "Application not found in any Steam library. Recommend dropping a steam_appid.txt yourself.", I've searched issues and seen many related issues about not able to get correct Steam App ID. In my case maybe due to new beta Steam client changes I think? Anyway, sometimes a Steam restart will solve the problem, sometimes will not. So I went for following the prompt and dropping the `steam_appid.txt` myself.

## The Problem
I found that the content of `steam_appid.txt` file is always overwritten with 0, further investigation shows that the code currently write the appid to file regardless of whether the ID is correctly obtained or is just the placeholder 0.

## The PR
This pr adds a detection to prevent the wrong 0 placeholder ID to be written to `steam_appid.txt`, thus allows the mod to be normally loaded with right ID provided, without the need of changing the file manually every launch. I don't have time to investigate why the ID cannot be obtained by SteamHook for now, but at least we can enable the recommended workaround to be applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steam AppID validation during startup. Now ensures only valid AppID values are written to configuration, preventing issues from invalid or unresolved identifiers being persisted to disk.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reloaded-Project/Reloaded-II/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->