### PR TITLE
Fixed: Launcher freezing on startup when fetching mod update metadata

### DIFF
--- a/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/ModUpdateDialogViewModel.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/ModUpdateDialogViewModel.cs
@@ -41,16 +41,25 @@ public class ModUpdateDialogViewModel : ObservableObject
     /// </summary>
     public bool CanDownload { get; set; }
 
-    /// <summary/>
-    public ModUpdateDialogViewModel(Updater updater, ModUpdateSummary summary)
+    /// <summary>
+    /// Creates the ViewModel using precomputed update info.
+    /// Prefer this overload; it performs no network I/O and is safe on the UI thread.
+    /// </summary>
+    public ModUpdateDialogViewModel(Updater updater, ModUpdateSummary summary, ModUpdate[] updateInfo)
     {
         Updater = updater;
         Summary = summary;
-        UpdateInfo = Summary.GetUpdateInfo();
+        UpdateInfo = updateInfo;
         TotalSize = UpdateInfo.Sum(x => x.UpdateSize);
         SelectedUpdate = UpdateInfo[0];
         CanDownload = true;
     }
+
+    /// <summary>
+    /// Legacy constructor. Performs blocking network I/O; do not call from the UI thread.
+    /// </summary>
+    public ModUpdateDialogViewModel(Updater updater, ModUpdateSummary summary)
+        : this(updater, summary, summary.GetUpdateInfo()) { }
 
     /// <summary>
     /// Performs an update of all mods.

--- a/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/ModUpdateDialogViewModel.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/ModUpdateDialogViewModel.cs
@@ -50,8 +50,17 @@ public class ModUpdateDialogViewModel : ObservableObject
         Summary = summary;
         UpdateInfo = updateInfo;
         TotalSize = UpdateInfo.Sum(x => x.UpdateSize);
-        SelectedUpdate = UpdateInfo[0];
-        CanDownload = true;
+
+        if (UpdateInfo.Length > 0)
+        {
+            SelectedUpdate = UpdateInfo[0];
+            CanDownload = true;
+        }
+        else
+        {
+            SelectedUpdate = null;
+            CanDownload = false;
+        }
     }
 
     /// <summary>

--- a/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/ModUpdateDialogViewModel.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Models/ViewModel/Dialog/ModUpdateDialogViewModel.cs
@@ -43,7 +43,6 @@ public class ModUpdateDialogViewModel : ObservableObject
 
     /// <summary>
     /// Creates the ViewModel using precomputed update info.
-    /// Prefer this overload; it performs no network I/O and is safe on the UI thread.
     /// </summary>
     public ModUpdateDialogViewModel(Updater updater, ModUpdateSummary summary, ModUpdate[] updateInfo)
     {
@@ -54,12 +53,6 @@ public class ModUpdateDialogViewModel : ObservableObject
         SelectedUpdate = UpdateInfo[0];
         CanDownload = true;
     }
-
-    /// <summary>
-    /// Legacy constructor. Performs blocking network I/O; do not call from the UI thread.
-    /// </summary>
-    public ModUpdateDialogViewModel(Updater updater, ModUpdateSummary summary)
-        : this(updater, summary, summary.GetUpdateInfo()) { }
 
     /// <summary>
     /// Performs an update of all mods.

--- a/source/Reloaded.Mod.Launcher.Lib/Update.cs
+++ b/source/Reloaded.Mod.Launcher.Lib/Update.cs
@@ -130,9 +130,14 @@ public static class Update
 
             if (updateDetails.HasUpdates())
             {
+                // Fetch update metadata (download sizes, changelogs) on a background thread.
+                // Doing this inside the ViewModel constructor blocked the UI thread on
+                // unbounded network I/O, freezing the launcher on startup. See issue #910.
+                var updateInfo = await updateDetails.GetUpdateInfoAsync();
+
                 Actions.SynchronizationContext.Send(_ =>
                 {
-                    Actions.ShowModUpdateDialog.Invoke(new ModUpdateDialogViewModel(updater, updateDetails));
+                    Actions.ShowModUpdateDialog.Invoke(new ModUpdateDialogViewModel(updater, updateDetails, updateInfo));
                 }, null);
 
                 return true;

--- a/source/Reloaded.Mod.Loader.Update/Structures/ModUpdateSummary.cs
+++ b/source/Reloaded.Mod.Loader.Update/Structures/ModUpdateSummary.cs
@@ -69,7 +69,7 @@ public class ModUpdateSummary
             {
                 try
                 {
-                    updateSize = await hasDownloadSize.GetDownloadFileSizeAsync(newVersion!, resultPairs.ModTuple.GetVerificationInfo());
+                    updateSize = await hasDownloadSize.GetDownloadFileSizeAsync(newVersion!, resultPairs.ModTuple.GetVerificationInfo()).ConfigureAwait(false);
                 }
                 catch (Exception) { /* Ignored */ }
             }
@@ -79,7 +79,7 @@ public class ModUpdateSummary
             {
                 try
                 {
-                    var releaseMetadata = await getMetadata.GetReleaseMetadataAsync(default);
+                    var releaseMetadata = await getMetadata.GetReleaseMetadataAsync(default).ConfigureAwait(false);
                     var extraData = releaseMetadata?.GetExtraData<ReleaseMetadataExtraData>();
                     if (extraData != null)
                         changelog = extraData.Changelog;
@@ -94,7 +94,7 @@ public class ModUpdateSummary
                 {
                     var copiedSettings = nugetResolver.GetResolverSettings();
                     var repository = NugetRepository.FromSourceUrl(copiedSettings.NugetRepository!.SourceUrl);
-                    var reader = await repository.DownloadNuspecReaderAsync(new PackageIdentity(copiedSettings.PackageId, newVersion!));
+                    var reader = await repository.DownloadNuspecReaderAsync(new PackageIdentity(copiedSettings.PackageId, newVersion!)).ConfigureAwait(false);
                     if (reader != null)
                         changelog = reader?.GetReleaseNotes();
                 }

--- a/source/Reloaded.Mod.Loader.Update/Structures/ModUpdateSummary.cs
+++ b/source/Reloaded.Mod.Loader.Update/Structures/ModUpdateSummary.cs
@@ -39,61 +39,65 @@ public class ModUpdateSummary
 
     /// <summary>
     /// Retrieves info about the individual updates.
+    /// Synchronous wrapper; do not call from the UI thread. Prefer <see cref="GetUpdateInfoAsync"/>.
     /// </summary>
     /// <returns></returns>
-    public ModUpdate[] GetUpdateInfo()
+    public ModUpdate[] GetUpdateInfo() => Task.Run(GetUpdateInfoAsync).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Retrieves info about the individual updates without blocking the calling thread.
+    /// </summary>
+    /// <returns></returns>
+    public async Task<ModUpdate[]> GetUpdateInfoAsync()
     {
         if (_updates != null) 
             return _updates;
 
-        _updates = new ModUpdate[ManagerModResultPairs.Count];
-        Task.Run(async () =>
+        var updates = new ModUpdate[ManagerModResultPairs.Count];
+        for (var x = 0; x < ManagerModResultPairs.Count; x++)
         {
-            for (var x = 0; x < ManagerModResultPairs.Count; x++)
-            {
-                var resultPairs = ManagerModResultPairs[x];
-                var modName = resultPairs.ModTuple.Config.ModName;
-                var modId = resultPairs.ModTuple.Config.ModId;
-                var oldVersion = resultPairs.ModTuple.Config.ModVersion;
-                var newVersion = resultPairs.Result.LastVersion;
-                var resolver = ((IPackageResolverDownloadSize)resultPairs.Manager.Resolver);
-                var updateSize = (long)0;
-                string? changelog = null;
+            var resultPairs = ManagerModResultPairs[x];
+            var modName = resultPairs.ModTuple.Config.ModName;
+            var modId = resultPairs.ModTuple.Config.ModId;
+            var oldVersion = resultPairs.ModTuple.Config.ModVersion;
+            var newVersion = resultPairs.Result.LastVersion;
+            var resolver = ((IPackageResolverDownloadSize)resultPairs.Manager.Resolver);
+            var updateSize = (long)0;
+            string? changelog = null;
 
+            try
+            {
+                updateSize = await resolver.GetDownloadFileSizeAsync(newVersion!, resultPairs.ModTuple.GetVerificationInfo());
+            }
+            catch (Exception) { /* Ignored */ }
+
+            // Get changelog from supported resolver.
+            if (resolver is IPackageResolverGetLatestReleaseMetadata getMetadata)
+            {
                 try
                 {
-                    updateSize = await resolver.GetDownloadFileSizeAsync(newVersion!, resultPairs.ModTuple.GetVerificationInfo());
+                    var releaseMetadata = await getMetadata.GetReleaseMetadataAsync(default);
+                    var extraData = releaseMetadata?.GetExtraData<ReleaseMetadataExtraData>();
+                    if (extraData != null)
+                        changelog = extraData.Changelog;
                 }
                 catch (Exception) { /* Ignored */ }
-
-                // Get changelog from supported resolver.
-                if (resolver is IPackageResolverGetLatestReleaseMetadata getMetadata)
-                {
-                    try
-                    {
-                        var releaseMetadata = await getMetadata.GetReleaseMetadataAsync(default);
-                        var extraData = releaseMetadata?.GetExtraData<ReleaseMetadataExtraData>();
-                        if (extraData != null)
-                            changelog = extraData.Changelog;
-                    }
-                    catch (Exception) { /* Ignored */ }
-                }
-
-                // NuGet has special case, since it doesn't support release metadata but supports changelogs in nuspec.
-                if (string.IsNullOrEmpty(changelog) && resolver is NuGetUpdateResolver nugetResolver)
-                {
-                    var copiedSettings = nugetResolver.GetResolverSettings();
-                    var repository = NugetRepository.FromSourceUrl(copiedSettings.NugetRepository!.SourceUrl);
-                    var reader = await repository.DownloadNuspecReaderAsync(new PackageIdentity(copiedSettings.PackageId, newVersion!));
-                    if (reader != null)
-                        changelog = reader?.GetReleaseNotes();
-                }
-
-                _updates[x] = new ModUpdate(modId, NuGetVersion.Parse(oldVersion), newVersion!, updateSize, changelog, modName);
             }
 
-        }).Wait();
+            // NuGet has special case, since it doesn't support release metadata but supports changelogs in nuspec.
+            if (string.IsNullOrEmpty(changelog) && resolver is NuGetUpdateResolver nugetResolver)
+            {
+                var copiedSettings = nugetResolver.GetResolverSettings();
+                var repository = NugetRepository.FromSourceUrl(copiedSettings.NugetRepository!.SourceUrl);
+                var reader = await repository.DownloadNuspecReaderAsync(new PackageIdentity(copiedSettings.PackageId, newVersion!));
+                if (reader != null)
+                    changelog = reader?.GetReleaseNotes();
+            }
 
+            updates[x] = new ModUpdate(modId, NuGetVersion.Parse(oldVersion), newVersion!, updateSize, changelog, modName);
+        }
+
+        _updates = updates;
         return _updates;
     }
 

--- a/source/Reloaded.Mod.Loader.Update/Structures/ModUpdateSummary.cs
+++ b/source/Reloaded.Mod.Loader.Update/Structures/ModUpdateSummary.cs
@@ -61,15 +61,18 @@ public class ModUpdateSummary
             var modId = resultPairs.ModTuple.Config.ModId;
             var oldVersion = resultPairs.ModTuple.Config.ModVersion;
             var newVersion = resultPairs.Result.LastVersion;
-            var resolver = ((IPackageResolverDownloadSize)resultPairs.Manager.Resolver);
+            var resolver = resultPairs.Manager.Resolver;
             var updateSize = (long)0;
             string? changelog = null;
 
-            try
+            if (resolver is IPackageResolverDownloadSize hasDownloadSize)
             {
-                updateSize = await resolver.GetDownloadFileSizeAsync(newVersion!, resultPairs.ModTuple.GetVerificationInfo());
+                try
+                {
+                    updateSize = await hasDownloadSize.GetDownloadFileSizeAsync(newVersion!, resultPairs.ModTuple.GetVerificationInfo());
+                }
+                catch (Exception) { /* Ignored */ }
             }
-            catch (Exception) { /* Ignored */ }
 
             // Get changelog from supported resolver.
             if (resolver is IPackageResolverGetLatestReleaseMetadata getMetadata)
@@ -87,11 +90,15 @@ public class ModUpdateSummary
             // NuGet has special case, since it doesn't support release metadata but supports changelogs in nuspec.
             if (string.IsNullOrEmpty(changelog) && resolver is NuGetUpdateResolver nugetResolver)
             {
-                var copiedSettings = nugetResolver.GetResolverSettings();
-                var repository = NugetRepository.FromSourceUrl(copiedSettings.NugetRepository!.SourceUrl);
-                var reader = await repository.DownloadNuspecReaderAsync(new PackageIdentity(copiedSettings.PackageId, newVersion!));
-                if (reader != null)
-                    changelog = reader?.GetReleaseNotes();
+                try
+                {
+                    var copiedSettings = nugetResolver.GetResolverSettings();
+                    var repository = NugetRepository.FromSourceUrl(copiedSettings.NugetRepository!.SourceUrl);
+                    var reader = await repository.DownloadNuspecReaderAsync(new PackageIdentity(copiedSettings.PackageId, newVersion!));
+                    if (reader != null)
+                        changelog = reader?.GetReleaseNotes();
+                }
+                catch (Exception) { /* Ignored */ }
             }
 
             updates[x] = new ModUpdate(modId, NuGetVersion.Parse(oldVersion), newVersion!, updateSize, changelog, modName);


### PR DESCRIPTION
Fixes #910

**Root cause:** `ModUpdateSummary.GetUpdateInfo()` performs per-mod network requests
(download sizes, changelogs, nuspec fetches) with no timeouts, wrapped in
`Task.Run(...).Wait()`. It was called from the `ModUpdateDialogViewModel` constructor,
which runs on the UI thread inside `SynchronizationContext.Send` — so any slow or
unresponsive package endpoint froze the launcher indefinitely on startup.
Full WinDbg analysis of a hang dump is in #910.

**Change:**
- `ModUpdateSummary`: added `GetUpdateInfoAsync()`; the sync `GetUpdateInfo()` remains
  as a wrapper for compatibility.
- `Update.CheckForModUpdatesAsync`: awaits the metadata fetch on the background thread
  *before* marshaling to the UI thread.
- `ModUpdateDialogViewModel`: new overload accepts precomputed update info; the dialog
  constructor now does no I/O.

**Verified:** Full solution builds (VS Community, v142 toolset for the bootstrapper).
Launched the built Reloaded-II.exe on the previously-freezing setup (Win11 26100,
mods with pending updates): startup completes and the update dialog appears normally.
All build warnings are pre-existing on master.

**Note:** the underlying requests still lack timeouts — a hung endpoint now stalls the
background check silently rather than the UI. Left out of this PR to keep it minimal;
happy to add a cancellation ceiling as a follow-up if wanted.